### PR TITLE
Added compatibility layer setup to browser tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -43,6 +43,11 @@ on:
                 description: "The branch from ibexa/ci-scripts repository that should be used"
                 required: false
                 type: string
+            use-compatibility-layer:
+                default: false
+                type: boolean
+                required: false
+                description: "Use the compatibility layer when running tests"
             timeout:
                 default: 30
                 description: "Job maximum timeout in minutes"
@@ -105,6 +110,14 @@ jobs:
                 curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/${{ inputs.project-version }}/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh
                 ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ inputs.project-version }} ${{ inputs.setup }} ${{ inputs.php-image }}
+
+            - if: inputs.use-compatibility-layer
+              name: Set up compatibility-layer
+              run: |
+                cd ${HOME}/build/project
+                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer require ibexa/compatibility-layer:^4.0.x-dev --no-scripts --no-plugins"
+                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer recipes:install ibexa/compatibility-layer --force"
+                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - if: inputs.multirepository
               name: Set up multirepository build


### PR DESCRIPTION
Adds tests running with compatibility-layer enabled.

All the code is rebranded, so there's not a lot this layer has to do, but at least we check:
1) that the routing for correct edition is applied
2) that the recipes content (including the Kernel class) is stil relevant

Companion PRs:
https://github.com/ibexa/oss/pull/36
https://github.com/ibexa/content/pull/28
https://github.com/ibexa/experience/pull/21
https://github.com/ibexa/commerce/pull/32

Steps were taken from:
https://doc.ibexa.co/en/master/updating/from_3.3/to_4.0/#add-compatibility-layer-package 