### PR TITLE
Added a way of selecting ci-scripts branch

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -38,6 +38,11 @@ on:
                 description: "The PHP image to use"
                 required: false
                 type: string
+            ci-scripts-branch:
+                default: "main"
+                description: "The branch from ibexa/ci-scripts repository that should be used"
+                required: false
+                type: string
             timeout:
                 default: 30
                 description: "Job maximum timeout in minutes"
@@ -97,7 +102,7 @@ jobs:
 
             - name: Set up whole project using the tested dependency
               run: |
-                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/${{ inputs.project-version }}/prepare_project_edition.sh" > prepare_project_edition.sh
+                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/${{ inputs.project-version }}/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh
                 ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ inputs.project-version }} ${{ inputs.setup }} ${{ inputs.php-image }}
 


### PR DESCRIPTION
This PR allows us to test changes to the ci-scripts repository (for example: https://github.com/ibexa/ci-scripts/pull/37)
by setting the `ci-scripts-branch` argument. It should be much easier than the current way of doing it.

Example usage:
https://github.com/ezsystems/BehatBundle/pull/260/files#diff-0d1742b44d1a1285f5590138b778e9a2a6dc73055a7cf4ee1741f4ca706664a0R19
(testing https://github.com/ibexa/ci-scripts/pull/37 )