### PR TITLE
[Browser tests] Moved multirepository setup to the workflow

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -121,7 +121,17 @@ jobs:
 
             - if: inputs.multirepository
               name: Set up multirepository build
-              run: $HOME/build/project/vendor/ezsystems/behatbundle/bin/.travis/prepare_multirepository_setup.sh
+              run: |
+                cd ${HOME}/build/project
+                # Drop database used by default connection
+                docker-compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+                # Clear SPI cache
+                docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+                # Run setup
+                docker-compose exec -T --user www-data app sh -c "vendor/bin/ezbehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml"
+                docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
+                # Reinstal database using the new repository
+                docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.test-setup-phase-1 != ''
               name: Run first phase of tests setup


### PR DESCRIPTION
Part of BehatBundle rebranding: https://issues.ibexa.co/browse/IBX-2322

After BehatBundle rebranding we would have to add IFs here, because the path of the script is `vendor/ezsystems/behatbundle...` on v3.3 and `vendor/ibexa/behat...` on v4.

I think moving it to this file is a cleaner option.