### PR TITLE
[Behat] Added clearing cache after every setup phase

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -139,13 +139,14 @@ jobs:
               run: |
                   cd ${HOME}/build/project
                   docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
+                  docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - if: inputs.test-setup-phase-2 != ''
               name: Run second phase of tests setup
               run: |
                   cd ${HOME}/build/project
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
                   docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
+                  docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - name: Run tests
               run: |


### PR DESCRIPTION
Needed to unblock CI in https://github.com/ezsystems/ezplatform-http-cache/pull/172 and merge it

You can see in https://github.com/ezsystems/ezplatform-http-cache/actions/workflows/browser-tests.yaml that the HTTP cache tests have not been really stable - a lot of the jobs fail with:
```
     And response headers contain                                                         # Ibexa\Behat\Browser\Context\BrowserContext::responseHeadersContain()
      | Header  | Value |
      | X-Cache | HIT   |

    Examples:
      | embeddingItemName  | embeddedItemName  |
      | EmbeddingItemNoEsi | EmbeddedItemNoEsi |
        Failed asserting that 0.089 is greater than '5'.
      | EmbeddingItemEsi   | EmbeddedItemEsi   |
        Failed asserting that 0.0867 is greater than '5'.
```

I've found that it's caused by not clearing the cache after the config is applied - sometimes Symfony takes into account and sometimes it doesn't. Clearing the cache solves the issue: I've tested it in https://github.com/ezsystems/ezplatform-http-cache/pull/173 (all tests green). I've decided to go with `composer run post-install-cmd`, to make it more bulletproof for the future.

Pros:
1. The setup phase will take longer

Cons:
1. The tests will be more reliable