### PR TITLE
[Browser tests] Expanded the setups when Varnish is used

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -102,7 +102,7 @@ jobs:
         outputs:
             report-url: ${{ steps.report.outputs.report-url }}
         steps:
-            - if: contains(inputs.setup, 'doc/docker/varnish.yml')
+            - if: contains(inputs.setup, 'varnish')
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=http://varnish" >> $GITHUB_ENV
 


### PR DESCRIPTION
https://github.com/ibexa/docker/pull/7/files adds a `varnish7` file that should be detected as Varnish setup as well.

Tested in https://github.com/ezsystems/ezplatform-http-cache/pull/175