### PR TITLE
[Browser tests] Fixed PR builds running only a subset of tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -177,7 +177,7 @@ jobs:
             - name: Run tests
               run: |
                   cd ${HOME}/build/project
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-suite }} --group-count=${{ inputs.job-count }} --group-offset=${{ matrix.offset }}"
+                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-suite }} --group-count=${{ env.JOB_COUNT }} --group-offset=${{ matrix.offset }}"
 
             - if: always()
               id: report


### PR DESCRIPTION
Tested in https://github.com/ibexa/commerce/pull/105

Right now our regression PRs do not run all of the tests, but only a subset.

You can see that the first build (https://github.com/ibexa/commerce/runs/7193861471?check_suite_focus=true) runs only 19 Scenarios, but the second one (with the fix included) runs all 57:
https://github.com/ibexa/commerce/runs/7194411154?check_suite_focus=true

For PRs we manually reduce the number of jobs to 1 - we should no longer rely on the inputs.job-count value.