### PR TITLE
[Browser tests] Added support for setting up releases

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -6,7 +6,7 @@ on:
                 required: true
                 type: string
             project-version:
-                description: "Project version to set up: ^3.3.x-dev, 4.0.x-dev, 4.1.x-dev, 4.2.x-dev"
+                description: "Project version to set up: ^3.3.x-dev, 4.1.x-dev, 4.2.x-dev, v3.3.0, v4.2.0"
                 required: true
                 type: string
             test-suite:
@@ -139,9 +139,17 @@ jobs:
                   SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
                   TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
 
-            - name: Set up whole project using the tested dependency
+            - if: startsWith(inputs.project-version, 'v') == false
+              name: Set up whole project using the tested dependency (dev version)
               run: |
                 curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/${{ inputs.project-version }}/prepare_project_edition.sh" > prepare_project_edition.sh
+                chmod +x prepare_project_edition.sh
+                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ inputs.project-version }} ${{ inputs.setup }} ${{ inputs.php-image }}
+
+            - if: startsWith(inputs.project-version, 'v')
+              name: Set up whole project using a stable release
+              run: |
+                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/stable/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh
                 ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ inputs.project-version }} ${{ inputs.setup }} ${{ inputs.php-image }}
 
@@ -149,7 +157,7 @@ jobs:
               name: Set up compatibility-layer
               run: |
                 cd ${HOME}/build/project
-                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer require ibexa/compatibility-layer:^4.0.x-dev --no-scripts --no-plugins"
+                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer require ibexa/compatibility-layer:${{ inputs.project-version }} --no-scripts --no-plugins"
                 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer recipes:install ibexa/compatibility-layer --force"
                 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2317

Requires: https://github.com/ibexa/ci-scripts/pull/53

This PR adds support for running tests on stable tags - there's a new script in ci-scripts that takes care of that.
