### PR TITLE
[Browser tests] Increased job maximum timeout to 60 minutes

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -59,7 +59,7 @@ on:
                 type: boolean
                 description: "Send a notification when the tests pass"
             timeout:
-                default: 30
+                default: 60
                 description: "Job maximum timeout in minutes"
                 required: false
                 type: number


### PR DESCRIPTION
Increased job maximum timeout to 60 minutes.

Value is changed globally.

Previous value of 30 minutes was causing timeouts. Already in some repos custom values were applied, e.g. 40 minutes in admin-ui.