### PR TITLE
Allow overriding group and group offset

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -192,7 +192,7 @@ jobs:
             - name: Run tests
               run: |
                   cd ${HOME}/build/project
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-suite }} --group-count=${{ needs.setup-jobs.outputs.job-count }} --group-offset=${{ matrix.offset }}"
+                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat --group-count=${{ needs.setup-jobs.outputs.job-count }} --group-offset=${{ matrix.offset }} ${{ inputs.test-suite }}"
 
             - if: always()
               id: report


### PR DESCRIPTION
With the current order (input first, groups second) it's not possible to override the values.
The proposed order makes it possible to specify something like:
`--profile=regression --suite=experience --group-count=4 --group-offset=3`
in a PR, which will run only a subset of tests.

This can be useful for debugging, as it allows to run a specific group on CI.

Tested in https://github.com/ibexa/page-builder/pull/180/commits/d43a4a58e5d13bcfbcedabb53cde45a3b482c65e
With build: https://github.com/ibexa/page-builder/actions/runs/3620877907/jobs/6103639775