### PR TITLE
Enable browser test workflow to use GH App token

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -139,7 +139,7 @@ jobs:
                   restore-keys: |
                     ${{ inputs.project-edition }}-${{ inputs.project-version }}-${{ inputs.php-image }}
 
-            - if: env.SATIS_NETWORK_KEY != ''
+            - if: env.AUTOMATION_CLIENT_SECRET != ''
               name: Generate token
               id: generate_token
               uses: tibdex/github-app-token@v1
@@ -154,11 +154,18 @@ jobs:
               name: Add composer keys for private packagist
               run: |
                   composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-                  composer config github-oauth.github.com $GITHUB_APP_TOKEN
+                  composer config github-oauth.github.com $GITHUB_TOKEN
               env:
                   SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
                   SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-                  GITHUB_APP_TOKEN: ${{ steps.generate_token.outputs.token }}
+                  GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+            - if: steps.generate_token.outputs.token != ''
+              name: Add composer key for GitHub App
+              run: |
+                  composer config github-oauth.github.com $GITHUB_TOKEN
+              env:
+                  GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
             - if: startsWith(inputs.project-version, 'v') == false
               name: Set up whole project using the tested dependency (dev version)

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -72,6 +72,12 @@ on:
                 required: false
             TRAVIS_GITHUB_TOKEN:
                 required: false
+            AUTOMATION_CLIENT_ID:
+                required: false
+            AUTOMATION_CLIENT_INSTALLATION:
+                required: false
+            AUTOMATION_CLIENT_SECRET:
+                required: false
             PERCY_TOKEN:
                 required: false
             CLOUDINARY_URL:
@@ -134,14 +140,23 @@ jobs:
                     ${{ inputs.project-edition }}-${{ inputs.project-version }}-${{ inputs.php-image }}
 
             - if: env.SATIS_NETWORK_KEY != ''
+              name: Generate token
+              id: generate_token
+              uses: tibdex/github-app-token@v1
+              with:
+                app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
+                private_key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+
+            - if: env.SATIS_NETWORK_KEY != ''
               name: Add composer keys for private packagist
               run: |
                   composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-                  composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+                  composer config github-oauth.github.com $GITHUB_APP_TOKEN
               env:
                   SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
                   SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-                  TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+                  GITHUB_APP_TOKEN: ${{ steps.generate_token.outputs.token }}
 
             - if: startsWith(inputs.project-version, 'v') == false
               name: Set up whole project using the tested dependency (dev version)

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -144,7 +144,7 @@ jobs:
               id: generate_token
               uses: tibdex/github-app-token@v1
               env:
-                  SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                  AUTOMATION_CLIENT_SECRET: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
               with:
                 app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                 installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -143,6 +143,8 @@ jobs:
               name: Generate token
               id: generate_token
               uses: tibdex/github-app-token@v1
+              env:
+                  SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
               with:
                 app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                 installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}


### PR DESCRIPTION
This will switch the browser tests from TRAVIS_GITHUB_TOKEN to using GH Application token, as per https://ibexa.atlassian.net/wiki/spaces/ENG/pages/12713999/Migrating+from+TRAVIS+GITHUB+TOKEN.

Note: the callee workflow must be updated by adding the following 3 lines to secrets:

```
            AUTOMATION_CLIENT_ID: ${{ secrets.AUTOMATION_CLIENT_ID }}
            AUTOMATION_CLIENT_INSTALLATION: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
            AUTOMATION_CLIENT_SECRET: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
```
As of this moment, necessary secrets have been created only in the ibexa organization, not ezsystems. TBF