### PR TITLE
[Browser tests] Enabled test sharding for PR builds

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -99,9 +99,6 @@ jobs:
         steps:
             - name: Set job count for builds
               run: echo "JOB_COUNT=${{ inputs.job-count }}" >> $GITHUB_ENV
-            - name: Set job count for PR builds
-              if: github.event_name == 'pull_request'
-              run: echo "JOB_COUNT=1" >> $GITHUB_ENV
             - name: Generate matrix
               id: generate-matrix
               run: |


### PR DESCRIPTION
After https://github.com/ibexa/gh-workflows/pull/30 we are working with higher Github API limits, which means we can enable test sharding in PR builds as well.

Tested in:
https://github.com/ibexa/commerce/pull/205
https://github.com/ibexa/commerce/actions/runs/4007016570/jobs/6879296836

Result: build time decreases from 2h to 30 min