### PR TITLE
Made project version optional

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -5,13 +5,13 @@ on:
                 description: "Project edition to set up: oss, content, experience, commerce"
                 required: true
                 type: string
-            project-version:
-                description: "Project version to set up: ^3.3.x-dev, 4.1.x-dev, 4.2.x-dev, v3.3.0, v4.2.0"
-                required: true
-                type: string
             test-suite:
                 description: "Browser tests to run"
                 required: true
+                type: string
+            project-version:
+                description: "Project version to set up: ^3.3.x-dev, 4.1.x-dev, 4.2.x-dev, v3.3.0, v4.2.0. If not present will be inferred from package's branch-alias"
+                required: false
                 type: string
             setup:
                 default: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
@@ -99,6 +99,9 @@ jobs:
         steps:
             - name: Set job count for builds
               run: echo "JOB_COUNT=${{ inputs.job-count }}" >> $GITHUB_ENV
+            - name: Set job count for v3.3 PR builds
+              if: github.event_name == 'pull_request' && inputs.project-version == '^3.3.x-dev'
+              run: echo "JOB_COUNT=1" >> $GITHUB_ENV
             - name: Generate matrix
               id: generate-matrix
               run: |
@@ -113,14 +116,23 @@ jobs:
         strategy:
           fail-fast: false
           matrix: ${{ fromJson(needs.setup-jobs.outputs.matrix) }}
-        outputs:
-            report-url: ${{ steps.report.outputs.report-url }}
         steps:
             - if: contains(inputs.setup, 'varnish')
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=http://varnish" >> $GITHUB_ENV
 
             - uses: actions/checkout@v2
+
+            - name: Set up project version
+              id: project-version
+              run: |
+                if [[ "$VERSION" == "" ]] ; then
+                    echo "Input project version not set, taking the value from composer.json"
+                    VERSION=$(cat composer.json | jq -r '.extra | ."branch-alias" | ."dev-main"')
+                fi
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              env:
+                VERSION: ${{ inputs.project-version }}
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -132,9 +144,9 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
-                  key: ${{ inputs.project-edition }}-${{ inputs.project-version }}-${{ inputs.php-image }}-${{ github.sha }}
+                  key: ${{ inputs.project-edition }}-${{ steps.project-version.outputs.version }}-${{ inputs.php-image }}-${{ github.sha }}
                   restore-keys: |
-                    ${{ inputs.project-edition }}-${{ inputs.project-version }}-${{ inputs.php-image }}
+                    ${{ inputs.project-edition }}-${{ steps.project-version.outputs.version }}-${{ inputs.php-image }}
 
             - if: env.AUTOMATION_CLIENT_SECRET != ''
               name: Generate token
@@ -164,28 +176,28 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-            - if: startsWith(inputs.project-version, 'v') == false
+            - if: startsWith(steps.project-version.outputs.version, 'v') == false
               name: Set up whole project using the tested dependency (dev version)
               run: |
-                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/${{ inputs.project-version }}/prepare_project_edition.sh" > prepare_project_edition.sh
+                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/${{ steps.project-version.outputs.version }}/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh
-                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ inputs.project-version }} ${{ inputs.setup }} ${{ inputs.php-image }}
+                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ steps.project-version.outputs.version }} ${{ inputs.setup }} ${{ inputs.php-image }}
               env:
                 PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
                 CLOUDINARY_URL: "${{ secrets.CLOUDINARY_URL }}"
 
-            - if: startsWith(inputs.project-version, 'v')
+            - if: startsWith(steps.project-version.outputs.version, 'v')
               name: Set up whole project using a stable release
               run: |
                 curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/stable/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh
-                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ inputs.project-version }} ${{ inputs.setup }} ${{ inputs.php-image }}
+                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ steps.project-version.outputs.version }} ${{ inputs.setup }} ${{ inputs.php-image }}
 
             - if: inputs.use-compatibility-layer
               name: Set up compatibility-layer
               run: |
                 cd ${HOME}/build/project
-                docker-compose --env-file=.env exec -T app sh -c "composer require ibexa/compatibility-layer:${{ inputs.project-version }} --no-scripts --no-plugins"
+                docker-compose --env-file=.env exec -T app sh -c "composer require ibexa/compatibility-layer:${{ steps.project-version.outputs.version }} --no-scripts --no-plugins"
                 docker-compose --env-file=.env exec -T app sh -c "composer recipes:install ibexa/compatibility-layer --force"
                 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 


### PR DESCRIPTION
Things done:
1) `project-version` input is now optional - if not passed it will be taken directly from the branch-alias defined in composer.json.

Example: https://github.com/ibexa/admin-ui/blob/main/composer.json#L82

This makes the maintenece much easier, because we won't have to update values when creating stable branches (https://github.com/ibexa/admin-ui/blob/main/.github/workflows/browser-tests.yaml#L16)

2) https://github.com/ibexa/gh-workflows/pull/31 was a step in the right direction, but missed that the higher limits are not available for v3 - and we should not introduce that for v3 version.

I'm bringing it back, only for v3 (where we will still be passing the `project-version` input)

Tested in https://github.com/ibexa/behat/pull/54