### PR TITLE
[Browser tests] Enabled Composer cache when installing compatibility-layer

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -185,8 +185,8 @@ jobs:
               name: Set up compatibility-layer
               run: |
                 cd ${HOME}/build/project
-                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer require ibexa/compatibility-layer:${{ inputs.project-version }} --no-scripts --no-plugins"
-                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer recipes:install ibexa/compatibility-layer --force"
+                docker-compose --env-file=.env exec -T app sh -c "composer require ibexa/compatibility-layer:${{ inputs.project-version }} --no-scripts --no-plugins"
+                docker-compose --env-file=.env exec -T app sh -c "composer recipes:install ibexa/compatibility-layer --force"
                 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - if: inputs.multirepository


### PR DESCRIPTION
Right now our compatibility-layer installation happens without access to Composer cache, see for example:
https://github.com/ibexa/oss/actions/runs/4098624088/jobs/7067870397
```
Run cd ${HOME}/build/project
Cannot create cache directory /root/.composer/cache/repo/https---repo.packagist.org/, or directory is not writable. Proceeding without cache
Info from [https://repo.packagist.org:](https://repo.packagist.org/) #StandWithUkraine
./composer.json has been updated
Running composer update ibexa/compatibility-layer
Loading composer repositories with package information
Cannot create cache directory /root/.composer/cache/repo/https---repo.packagist.org/, or directory is not writable. Proceeding without cache
Info from [https://repo.packagist.org:](https://repo.packagist.org/) #StandWithUkraine
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking ibexa/compatibility-layer (dev-main 94aa9ff)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
Cannot create cache directory /root/.composer/cache/files/, or directory is not writable. Proceeding without cache
  - Downloading ibexa/compatibility-layer (dev-main 94aa9ff)
  - Installing ibexa/compatibility-layer (dev-main 94aa9ff): Extracting archive
Package sensio/framework-extra-bundle is abandoned, you should avoid using it. Use Symfony instead.
Package swiftmailer/swiftmailer is abandoned, you should avoid using it. Use symfony/mailer instead.
Package symfony/swiftmailer-bundle is abandoned, you should avoid using it. Use symfony/mailer instead.
Generating optimized autoload files
135 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Run command with -v to see more details

Cannot create cache directory /root/.composer/cache/repo/flex/, or directory is not writable. Proceeding without cache

Symfony operations: 1 recipe (cedd432d7621c87aaa2f6481733b855a)
  - Configuring ibexa/compatibility-layer (>=4.4): From github.com/ibexa/recipes-dev:master
```

This is because our Docker stack maps the Composer cache to the root directory (https://github.com/ibexa/docker/blob/main/docker/base-dev.yml#L9) to which the `www-data` user doesn't have access

With this change, tested in https://github.com/ibexa/oss/pull/84:
```
./composer.json has been updated
Running composer update ibexa/compatibility-layer
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking ibexa/compatibility-layer (dev-main 94aa9ff)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading ibexa/compatibility-layer (dev-main 94aa9ff)
  - Installing ibexa/compatibility-layer (dev-main 94aa9ff): Extracting archive
Package sensio/framework-extra-bundle is abandoned, you should avoid using it. Use Symfony instead.
Package swiftmailer/swiftmailer is abandoned, you should avoid using it. Use symfony/mailer instead.
Package symfony/swiftmailer-bundle is abandoned, you should avoid using it. Use symfony/mailer instead.
Generating optimized autoload files
135 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Run command with -v to see more details


Symfony operations: 1 recipe (9c25063f61feb16573fdebaebde4721d)
  - Configuring ibexa/compatibility-layer (>=4.4): From github.com/ibexa/recipes-dev:master
```

The permission warnings are gone, meaning we should see less authentication failures on github (Composer cache should be reused more often)

