### PR TITLE
[Browser tests] Limited job-count for v4 to 3

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -99,7 +99,16 @@ jobs:
         steps:
             - name: Set job count for builds
               run: echo "JOB_COUNT=${{ inputs.job-count }}" >> $GITHUB_ENV
-            - name: Set job count for v3.3 PR builds
+            - name: (v4) Limit job-count to max 3 for PRs
+              if: github.event_name == 'pull_request'
+              run: |
+                if [[ "$JOB_COUNT" -gt 3 ]] ; then
+                  JOB_COUNT=3
+                fi
+                echo "JOB_COUNT=$JOB_COUNT" >> $GITHUB_ENV
+              env:
+                JOB_COUNT: ${{ env.JOB_COUNT }}
+            - name: (v3) Limit job-count to 1 for PRs
               if: github.event_name == 'pull_request' && inputs.project-version == '^3.3.x-dev'
               run: echo "JOB_COUNT=1" >> $GITHUB_ENV
             - name: Generate matrix


### PR DESCRIPTION
To avoid hitting GitHub API limits we need to find the sweet spot for the number of jobs running the tests - I've seen Github Api limit exceeded last week (on Tuesday), this PR changes the logic to limit the number of jobs for v4 PRs.

> **Note**
> The new logic looks like this:

|Version|Is a Pull Request|Job Count in config|Result|Comment|
|---|---|---|---|---|
|v3| No| 4|4| Non-PR runs: the job number from config is taken|
|v4| No| 4|4| Non-PR runs: the job number from config is taken|
|v3| Yes| 3|1| v3 PR runs: the job number is always 1|
|v4| Yes| 4|3| v4 PR runs: the job number is capped at 3|
|v4| Yes| 2|2| v4 PR runs: the job number is capped at 3|

Tested in https://github.com/ibexa/commerce/pull/218

Why 3? Well, I don't have the data to back it up - right now some jobs are running with 4 (https://github.com/ibexa/commerce/blob/master/.github/workflows/browser-tests.yml#L51), so we know that it's too much - 3 is just the next step, we might need to lower it in the future.