### PR TITLE
[CI] Bumped Slack action version

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -278,7 +278,7 @@ jobs:
 
             - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v1.16.0
+              uses: slackapi/slack-github-action@v1.23.0
               with:
                   payload: ${{ env.SLACK_PAYLOAD }}
               env:


### PR DESCRIPTION
Small follow-up to get rid of the last deprecation notice:
https://github.com/ibexa/admin-ui/actions/runs/4371651951

It's no triggered on PR runs, that's why we didn't catch it.