### PR TITLE
IBX-5533: Reusable changelog workflow for bundles

### DIFF
--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -1,0 +1,45 @@
+name: Create Release for tag
+
+on:
+  workflow_call:
+    secrets:
+      JIRA_TOKEN:
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set Environment
+        run: |
+          echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Get previous release tag based on type
+        id: prevrelease
+        uses: ibexa/version-logic-action@master
+        with:
+          currentTag: ${{ env.BUILD_TAG }}
+
+      - name: Generate changelog
+        id: changelog
+        uses: ibexa/changelog-generator-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          jira_token: ${{ secrets.JIRA_TOKEN }}
+          currentTag: ${{ env.BUILD_TAG }}
+          previousTag: ${{ steps.prevrelease.outputs.previousTag }}
+
+      - name: Print the changelog
+        run: echo "${{ steps.changelog.outputs.changelog }}"
+
+      - name: Create Release
+        id: create_release
+        uses: zendesk/action-create-release@v1
+        with:
+          tag_name: ${{ env.BUILD_TAG }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: zendesk/action-create-release@v1
+        uses: zendesk/action-gh-release@v1
         with:
           tag_name: ${{ env.BUILD_TAG }}
           body: |

--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        uses: ibexa/changelog-generator-action@v2
+        uses: ibexa/changelog-generator-action@IBX-5533
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           jira_token: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
This reusable workflow is to replace the one hard-coded in repositories for bundles.
Like ibexa/admin-ui, product-catalog etc.

It is supposed to be called like this:

```
name: Call Automatic Changelog Generator for tag Workflow

on:  
  push:
    tags:
      - 'v*'
      - '!v*-alpha*'

jobs:
  create_release_for_tag:
    uses: ibexa/gh-workflows/.github/workflows/release_bundle.yml@main
    secrets:
      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
```

That way "when to run" is on the repository side, but "what to run" is externalized.