### PR TITLE
Added workaround for 3.3.x-dev version detection

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -139,6 +139,9 @@ jobs:
                     echo "Input project version not set, taking the value from composer.json"
                     version=$(cat composer.json | jq -r '.extra | ."branch-alias" | .[]')
                 fi
+                if [[ "$version" == "3.3.x-dev" ]] ; then
+                    version="^3.3.x-dev"
+                fi
                 echo "version=$version" >> $GITHUB_OUTPUT
               env:
                 version: ${{ inputs.project-version }}


### PR DESCRIPTION
The automatic version detection is based on the value present in composer.json.

For 3.3 it detects `3.3.x-dev`, but our script for that version in `ci-scripts` is called `^3.3.x-dev` - it's not worth changing everything for 3.3 to fix that, so this workaround is enough to have working automatic version detection for 3.3.

It's needed for:
https://github.com/ibexa/oss/pull/105