### PR TITLE
Set error reporting to E_ALL&~E_DEPRECATED for PHP 8

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -188,6 +188,10 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
+            - if: contains(inputs.php-image, 'php:8')
+              name: Set PHP error reporting
+              run: echo "PHP_INI_ENV_error_reporting=E_ALL&~E_DEPRECATED" >> $GITHUB_ENV
+
             - if: startsWith(steps.project-version.outputs.version, 'v') == false
               name: Set up whole project using the tested dependency (dev version)
               run: |


### PR DESCRIPTION
This sets error reporting:
```
error_reporting = E_ALL & ~E_DEPRECATED
```
for PHP 8.0+.

Requires: https://github.com/ibexa/docker/pull/18
Tested in: https://github.com/ezsystems/BehatBundle/pull/294