### PR TITLE
[Browser tests] Removed setting error reporting for PHP 8.2

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -188,10 +188,6 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-            - if: contains(inputs.php-image, 'php:8')
-              name: Set PHP error reporting
-              run: echo "PHP_INI_ENV_error_reporting=E_ALL&~E_DEPRECATED" >> $GITHUB_ENV
-
             - if: startsWith(steps.project-version.outputs.version, 'v') == false
               name: Set up whole project using the tested dependency (dev version)
               run: |


### PR DESCRIPTION
This approach did not work, replaced by https://github.com/ibexa/ci-scripts/pull/80

It didn't work because Symfony sets the error reporting level to all in debug mode - and ignores the original setting.