### PR TITLE
IBX-6507: Separated multi repository setups depending on search engine

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -239,7 +239,7 @@ jobs:
                 # Run setup
                 docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@elastic"
                 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
-                # Reinstal database using the new repository
+                # Reinstall database using the new repository
                 docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.multirepository && contains(inputs.setup, 'elastic.yml')
@@ -253,7 +253,7 @@ jobs:
                 # Run setup
                 docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@solr"
                 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
-                # Reinstal database using the new repository
+                # Reinstall database using the new repository
                 docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.multirepository && !contains(inputs.setup, 'elastic.yml') && !contains(inputs.setup, 'solr.yml')
@@ -265,9 +265,9 @@ jobs:
                 # Clear SPI cache
                 docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
                 # Run setup
-                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=@lse"
+                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=@multirepository"
                 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
-                # Reinstal database using the new repository
+                # Reinstall database using the new repository
                 docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.test-setup-phase-1 != ''

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -228,7 +228,21 @@ jobs:
                 docker-compose --env-file=.env exec -T app sh -c "composer recipes:install ibexa/compatibility-layer --force"
                 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
-            - if: inputs.multirepository
+            - if: inputs.multirepository && inputs.project-edition == 'oss'
+              name: Set up multirepository build
+              run: |
+                cd ${HOME}/build/project
+                # Drop database used by default connection
+                docker-compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+                # Clear SPI cache
+                docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+                # Run setup
+                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@IbexaContent,~@IbexaExperience,~@IbexaCommerce"
+                docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
+                # Reinstal database using the new repository
+                docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
+
+            - if: inputs.multirepository && inputs.project-edition != 'oss'
               name: Set up multirepository build
               run: |
                 cd ${HOME}/build/project

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -228,8 +228,8 @@ jobs:
                 docker-compose --env-file=.env exec -T app sh -c "composer recipes:install ibexa/compatibility-layer --force"
                 docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
-            - if: inputs.multirepository && inputs.project-edition == 'oss'
-              name: Set up multirepository build
+            - if: inputs.multirepository && contains(inputs.setup, 'solr.yml')
+              name: Set up multirepository build with Solr
               run: |
                 cd ${HOME}/build/project
                 # Drop database used by default connection
@@ -237,13 +237,13 @@ jobs:
                 # Clear SPI cache
                 docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
                 # Run setup
-                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@IbexaContent,~@IbexaExperience,~@IbexaCommerce"
+                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@elastic"
                 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
                 # Reinstal database using the new repository
                 docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
-            - if: inputs.multirepository && inputs.project-edition != 'oss'
-              name: Set up multirepository build
+            - if: inputs.multirepository && contains(inputs.setup, 'elastic.yml')
+              name: Set up multirepository build with Elastic
               run: |
                 cd ${HOME}/build/project
                 # Drop database used by default connection
@@ -251,7 +251,21 @@ jobs:
                 # Clear SPI cache
                 docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
                 # Run setup
-                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml"
+                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@solr"
+                docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
+                # Reinstal database using the new repository
+                docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
+
+            - if: inputs.multirepository && !contains(inputs.setup, 'elastic.yml') && !contains(inputs.setup, 'solr.yml')
+              name: Set up multirepository build with LSE
+              run: |
+                cd ${HOME}/build/project
+                # Drop database used by default connection
+                docker-compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+                # Clear SPI cache
+                docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+                # Run setup
+                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=@lse"
                 docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
                 # Reinstal database using the new repository
                 docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"


### PR DESCRIPTION
**JIRA:** https://issues.ibexa.co/browse/IBX-6507

Before multi repo setup did not take into account the type of search engine.

Now setup is divided into three: for Solr, for Elastic and for Legacy (SQL) Search Engine.

Companion PR: https://github.com/ibexa/behat/pull/108