### PR TITLE
Migrate to Compose V2

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -224,70 +224,70 @@ jobs:
               name: Set up compatibility-layer
               run: |
                 cd ${HOME}/build/project
-                docker-compose --env-file=.env exec -T app sh -c "composer require ibexa/compatibility-layer:${{ steps.project-version.outputs.version }} --no-scripts --no-plugins"
-                docker-compose --env-file=.env exec -T app sh -c "composer recipes:install ibexa/compatibility-layer --force"
-                docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                docker compose --env-file=.env exec -T app sh -c "composer require ibexa/compatibility-layer:${{ steps.project-version.outputs.version }} --no-scripts --no-plugins"
+                docker compose --env-file=.env exec -T app sh -c "composer recipes:install ibexa/compatibility-layer --force"
+                docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - if: inputs.multirepository && contains(inputs.setup, 'solr.yml')
               name: Set up multirepository build with Solr
               run: |
                 cd ${HOME}/build/project
                 # Drop database used by default connection
-                docker-compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+                docker compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
                 # Clear SPI cache
-                docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+                docker compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
                 # Run setup
-                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@elastic"
-                docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
+                docker compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@elastic"
+                docker compose exec -T --user www-data app sh -c "composer run post-install-cmd"
                 # Reinstall database using the new repository
-                docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
+                docker compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.multirepository && contains(inputs.setup, 'elastic.yml')
               name: Set up multirepository build with Elastic
               run: |
                 cd ${HOME}/build/project
                 # Drop database used by default connection
-                docker-compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+                docker compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
                 # Clear SPI cache
-                docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+                docker compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
                 # Run setup
-                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@solr"
-                docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
+                docker compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=~@solr"
+                docker compose exec -T --user www-data app sh -c "composer run post-install-cmd"
                 # Reinstall database using the new repository
-                docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
+                docker compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.multirepository && !contains(inputs.setup, 'elastic.yml') && !contains(inputs.setup, 'solr.yml')
               name: Set up multirepository build with LSE
               run: |
                 cd ${HOME}/build/project
                 # Drop database used by default connection
-                docker-compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
+                docker compose exec -T --user www-data app sh -c "php bin/console doctrine:database:drop --connection=default --force"
                 # Clear SPI cache
-                docker-compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
+                docker compose exec -T --user www-data app sh -c 'php bin/console cache:pool:clear ${CACHE_POOL:-cache.tagaware.filesystem}'
                 # Run setup
-                docker-compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=@multirepository"
-                docker-compose exec -T --user www-data app sh -c "composer run post-install-cmd"
+                docker compose exec -T --user www-data app sh -c "vendor/bin/ibexabehat --mode=standard --profile=setup --suite=multirepository -c=behat_ibexa_oss.yaml --tags=@multirepository"
+                docker compose exec -T --user www-data app sh -c "composer run post-install-cmd"
                 # Reinstall database using the new repository
-                docker-compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
+                docker compose exec -T --user www-data app sh -c "php bin/console ibexa:install"
 
             - if: inputs.test-setup-phase-1 != ''
               name: Run first phase of tests setup
               run: |
                   cd ${HOME}/build/project
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - if: inputs.test-setup-phase-2 != ''
               name: Run second phase of tests setup
               run: |
                   cd ${HOME}/build/project
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
 
             - name: Run tests
               run: |
                   cd ${HOME}/build/project
-                  docker-compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat --group-count=${{ needs.setup-jobs.outputs.job-count }} --group-offset=${{ matrix.offset }} ${{ inputs.test-suite }} --process=1"
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat --group-count=${{ needs.setup-jobs.outputs.job-count }} --group-offset=${{ matrix.offset }} ${{ inputs.test-suite }} --process=1"
 
             - if: always() && github.event_name != 'pull_request'
               name: Create Slack message variables


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 
    - https://github.com/ibexa/ci-scripts/pull/86

#### Description:
Docker compose v1 is being removed from Ubuntu images on GitHub Actions, ref. https://github.com/actions/runner-images/issues/9557. 
It started on April 1 and it will take a few days to complete the rollout process. That's why now some jobs work (using older images) and some don't (using newer images).

We need to migrate in our scripts from using docker compose v1 to docker compose v2, ref. https://docs.docker.com/compose/migrate/.

Example failure:

`./prepare_project_edition.sh: line 152: docker-compose: command not found`

ref. https://github.com/ibexa/oss/actions/runs/8529904557/job/23366655720.

Example failing image: 
20240401.4.0.
Example working image:
20240324.2.0.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
