### PR TITLE
IBX-9251: Run browser tests on different Ubuntu versions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -64,7 +64,7 @@ on:
                 required: false
                 type: number
             selected-os:
-                default: "ubuntu-latest"
+                default: ""
                 description: "Ubuntu OS version"
                 required: false
                 type: string
@@ -126,9 +126,13 @@ jobs:
             - name: Select Random OS
               id: select-os
               run: |
-                OS_ARRAY=("ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04")
-                RANDOM_INDEX=$(( RANDOM % ${#OS_ARRAY[@]} ))
-                SELECTED_OS=${OS_ARRAY[$RANDOM_INDEX]}
+                if [ -z "${{ github.event.inputs.selected-os }}" ]; then
+                  OS_ARRAY=("ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04")
+                  RANDOM_INDEX=$(( RANDOM % ${#OS_ARRAY[@]} ))
+                  SELECTED_OS=${OS_ARRAY[$RANDOM_INDEX]}
+                else
+                  SELECTED_OS=${{ github.event.inputs.selected-os }}
+                fi
                 echo "selected-os=$SELECTED_OS" >> $GITHUB_ENV
                 echo "selected-os=$SELECTED_OS" >> $GITHUB_OUTPUT
             - name: Generate matrix

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -97,8 +97,7 @@ env:
 
 jobs:
     setup-jobs:
-        runs-on:
-          group: ubuntu-runners
+        runs-on: ubuntu-latest
         timeout-minutes: 1
         outputs:
           matrix: ${{ steps.generate-matrix.outputs.matrix }}
@@ -118,6 +117,14 @@ jobs:
             - name: (v3) Limit job-count to 1 for PRs
               if: github.event_name == 'pull_request' && inputs.project-version == '^3.3.x-dev'
               run: echo "job_count=1" >> $GITHUB_ENV
+            - name: Select Random OS
+              id: select-os
+              run: |
+                OS_ARRAY=("ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04")
+                RANDOM_INDEX=$(( RANDOM % ${#OS_ARRAY[@]} ))
+                SELECTED_OS=${OS_ARRAY[$RANDOM_INDEX]}
+                echo "selected_os=$SELECTED_OS" >> $GITHUB_ENV
+                echo "selected_os=$SELECTED_OS" >> $GITHUB_OUTPUT
             - name: Generate matrix
               id: generate-matrix
               run: |
@@ -127,13 +134,14 @@ jobs:
 
     browser-tests:
         needs: setup-jobs
-        runs-on:
-          group: ubuntu-runners
+        runs-on: ${{ needs.setup-jobs.outputs.selected_os }}
         timeout-minutes: ${{ inputs.timeout }}
         strategy:
           fail-fast: false
           matrix: ${{ fromJson(needs.setup-jobs.outputs.matrix) }}
         steps:
+            - name: Check OS
+              run: echo "Running on ${{ runner.os }}"
             - if: contains(inputs.setup, 'varnish')
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=http://varnish" >> $GITHUB_ENV

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -63,7 +63,7 @@ on:
                 description: "Job maximum timeout in minutes"
                 required: false
                 type: number
-            selected_os:
+            selected-os:
                 default: "ubuntu-latest"
                 description: "Ubuntu OS version"
                 required: false
@@ -107,6 +107,7 @@ jobs:
         outputs:
           matrix: ${{ steps.generate-matrix.outputs.matrix }}
           job-count: ${{ steps.generate-matrix.outputs.job-count }}
+          selected-os: ${{ steps.select-os.outputs.selected-os }}
         steps:
             - name: Set job count for builds
               run: echo "job_count=${{ inputs.job-count }}" >> $GITHUB_ENV
@@ -128,8 +129,8 @@ jobs:
                 OS_ARRAY=("ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04")
                 RANDOM_INDEX=$(( RANDOM % ${#OS_ARRAY[@]} ))
                 SELECTED_OS=${OS_ARRAY[$RANDOM_INDEX]}
-                echo "selected_os=$SELECTED_OS" >> $GITHUB_ENV
-                echo "selected_os=$SELECTED_OS" >> $GITHUB_OUTPUT
+                echo "selected-os=$SELECTED_OS" >> $GITHUB_ENV
+                echo "selected-os=$SELECTED_OS" >> $GITHUB_OUTPUT
             - name: Generate matrix
               id: generate-matrix
               run: |
@@ -139,7 +140,7 @@ jobs:
 
     browser-tests:
         needs: setup-jobs
-        runs-on: ${{ needs.setup-jobs.outputs.selected_os }}
+        runs-on: ${{ needs.setup-jobs.outputs.selected-os }}
         timeout-minutes: ${{ inputs.timeout }}
         strategy:
           fail-fast: false

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -150,6 +150,7 @@ jobs:
               id: set-output
               run: |
                 echo "selected-os=$(cat selected_os.txt)" >> $GITHUB_OUTPUT
+                echo "Extracted value is: ${selected-os}"
             - name: Generate matrix
               id: generate-matrix
               run: |

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -107,7 +107,7 @@ jobs:
         outputs:
           matrix: ${{ steps.generate-matrix.outputs.matrix }}
           job-count: ${{ steps.generate-matrix.outputs.job-count }}
-          selected-os: ${{ steps.set-output.outputs.selected-os }}
+          selected-os: ${{ steps.set-output.outputs.selected_os }}
         steps:
             - name: Set job count for builds
               run: echo "job_count=${{ inputs.job-count }}" >> $GITHUB_ENV
@@ -149,8 +149,8 @@ jobs:
             - name: Extract Selected OS for Outputs
               id: set-output
               run: |
-                echo "selected-os=$(cat selected_os.txt)" >> $GITHUB_OUTPUT
-                echo "Extracted value is: ${selected-os}"
+                echo "selected_os=$(cat selected_os.txt)" >> $GITHUB_OUTPUT
+                echo "Extracted value is: ${selected_os}"
             - name: Generate matrix
               id: generate-matrix
               run: |

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -63,6 +63,11 @@ on:
                 description: "Job maximum timeout in minutes"
                 required: false
                 type: number
+            selected_os:
+                default: "ubuntu-latest"
+                description: "Ubuntu OS version"
+                required: false
+                type: string
         secrets:
             SLACK_WEBHOOK_URL:
                 required: true

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -150,7 +150,8 @@ jobs:
               id: set-output
               run: |
                 echo "selected_os=$(cat selected_os.txt)" >> $GITHUB_OUTPUT
-                echo "Extracted value is: ${selected_os}"
+                echo "Extracted value is: selected_os=$(cat selected_os.txt)"
+                echo "Debug: $GITHUB_OUTPUT"
             - name: Generate matrix
               id: generate-matrix
               run: |

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -97,7 +97,8 @@ env:
 
 jobs:
     setup-jobs:
-        runs-on: ubuntu-24.04 # Current latest (stable) is 22.04
+        runs-on:
+          group: ubuntu-runners
         timeout-minutes: 1
         outputs:
           matrix: ${{ steps.generate-matrix.outputs.matrix }}
@@ -126,7 +127,8 @@ jobs:
 
     browser-tests:
         needs: setup-jobs
-        runs-on: ubuntu-24.04
+        runs-on:
+          group: ubuntu-runners
         timeout-minutes: ${{ inputs.timeout }}
         strategy:
           fail-fast: false

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -152,6 +152,7 @@ jobs:
                 echo "selected_os=$(cat selected_os.txt)" >> $GITHUB_OUTPUT
                 echo "Extracted value is: selected_os=$(cat selected_os.txt)"
                 echo "Debug: $GITHUB_OUTPUT"
+                echo "Debug: $(cat $GITHUB_OUTPUT)"
             - name: Generate matrix
               id: generate-matrix
               run: |

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -64,7 +64,7 @@ on:
                 required: false
                 type: number
             selected-os:
-                default: ""
+                default: "ubuntu-latest"
                 description: "Ubuntu OS version"
                 required: false
                 type: string
@@ -107,7 +107,7 @@ jobs:
         outputs:
           matrix: ${{ steps.generate-matrix.outputs.matrix }}
           job-count: ${{ steps.generate-matrix.outputs.job-count }}
-          selected-os: ${{ steps.select-os.outputs.selected-os }}
+          selected-os: ${{ steps.set-output.outputs.selected-os }}
         steps:
             - name: Set job count for builds
               run: echo "job_count=${{ inputs.job-count }}" >> $GITHUB_ENV
@@ -123,18 +123,33 @@ jobs:
             - name: (v3) Limit job-count to 1 for PRs
               if: github.event_name == 'pull_request' && inputs.project-version == '^3.3.x-dev'
               run: echo "job_count=1" >> $GITHUB_ENV
+            - name: Download Artifact (if it exists)
+              uses: actions/download-artifact@v3
+              with:
+                name: selected-os
+                path: .
             - name: Select Random OS
               id: select-os
               run: |
-                if [ -z "${{ github.event.inputs.selected-os }}" ]; then
+                if [ ! -f selected_os.txt ]; then
+                  echo "selected_os.txt not found. Selecting a random OS."
                   OS_ARRAY=("ubuntu-20.04" "ubuntu-22.04" "ubuntu-24.04")
                   RANDOM_INDEX=$(( RANDOM % ${#OS_ARRAY[@]} ))
                   SELECTED_OS=${OS_ARRAY[$RANDOM_INDEX]}
+                  echo "$SELECTED_OS" > selected_os.txt
                 else
-                  SELECTED_OS=${{ github.event.inputs.selected-os }}
+                  echo "selected_os.txt exists. Using previously selected OS."
+                  cat selected_os.txt
                 fi
-                echo "selected-os=$SELECTED_OS" >> $GITHUB_ENV
-                echo "selected-os=$SELECTED_OS" >> $GITHUB_OUTPUT
+            - name: Upload Artifact
+              uses: actions/upload-artifact@v3
+              with:
+                name: selected-os
+                path: selected_os.txt
+            - name: Extract Selected OS for Outputs
+              id: set-output
+              run: |
+                echo "selected-os=$(cat selected_os.txt)" >> $GITHUB_OUTPUT
             - name: Generate matrix
               id: generate-matrix
               run: |

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -146,8 +146,10 @@ jobs:
           fail-fast: false
           matrix: ${{ fromJson(needs.setup-jobs.outputs.matrix) }}
         steps:
-            - name: Check OS
-              run: echo "Running on ${{ runner.os }}"
+            - name: Check Ubuntu Version
+              run: |
+                source /etc/os-release
+                echo "Running on Ubuntu version $VERSION_ID"
             - if: contains(inputs.setup, 'varnish')
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=http://varnish" >> $GITHUB_ENV

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -97,7 +97,7 @@ env:
 
 jobs:
     setup-jobs:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04 # Current latest (stable) is 22.04
         timeout-minutes: 1
         outputs:
           matrix: ${{ steps.generate-matrix.outputs.matrix }}
@@ -126,7 +126,7 @@ jobs:
 
     browser-tests:
         needs: setup-jobs
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         timeout-minutes: ${{ inputs.timeout }}
         strategy:
           fail-fast: false

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -124,10 +124,10 @@ jobs:
               if: github.event_name == 'pull_request' && inputs.project-version == '^3.3.x-dev'
               run: echo "job_count=1" >> $GITHUB_ENV
             - name: Download Artifact (if it exists)
-              uses: actions/download-artifact@v3
-              with:
-                name: selected-os
-                path: .
+              run: |
+                if ! actions/download-artifact --name selected-os --path .; then
+                  echo "Artifact not found. Continuing without it."
+                fi
             - name: Select Random OS
               id: select-os
               run: |


### PR DESCRIPTION
| :ticket: Issue | IBX-9251 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Run on Ubuntu 24.04, 22.04 and 20.04. Chosen randomly for given setup - each job in a setup gets the same OS version.

Ref. https://doc.ibexa.co/en/latest/getting_started/requirements/#operating-system

Pros of approach:
- no extra jobs are introduced (no impact on API limits)

Cons:
- in case of failed jobs and restarts, different Ubuntu edition might be chosen (could increase diagnosis time, if fail was edition related)

#### For QA:
Q: Can runners in a group be used? (initial idea)
A: Runner groups are meant to be used with self-hosted runners only, not for Github-hosted ones.

Open question: Since Docker is used for different versions of services, what exactly is the impact of different Ubuntu editions?

#### Summary:
Result of restarting a job:
- single "browser tests" job - Ubuntu version is kept
- "setup jobs" job (triggers restart of all "browser tests" jobs in that setup) - Ubuntu version is not kept
- "Re-run all jobs" button - Ubuntu versions are not kept

Using artifacts with a file holding chosen Ubuntu version is not sufficient. Artifacts are not shared between workflow runs which turned out includes restarts.
A possible solution could be to combine artifacts with an external cloud storage. Sounds like overengineering.

The cost in complexity to join increased coverage with good reliability without affecting API limits is too high. If at all possible for all scenarios. For now reliability of tests is key. Topic can be revisited if new GHA mechanisms surface.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
