### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -155,7 +155,7 @@ jobs:
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: 8.3
                   coverage: none
 
             - name: Cache dependencies


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|

#### Description:

This PR bumps Symfony to v6 with codebase upgrades.

Key changes:

- [x] Bumped PHP version to 8.3

#### QA:

N/A

#### Documentation:

N/A


