### PR TITLE
IBX-9627: [GHA] Created Rector PHP reusable workflow

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -1,0 +1,46 @@
+name: Rector PHP
+
+on:
+    workflow_call:
+        secrets:
+            SATIS_NETWORK_KEY:
+                required: false
+            SATIS_NETWORK_TOKEN:
+                required: false
+            TRAVIS_GITHUB_TOKEN:
+                required: false
+jobs:
+    rector:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup PHP Action
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+
+            - if: env.SATIS_NETWORK_KEY != ''
+              name: 'Add composer keys for private packagist'
+              run: |
+                  composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+                  composer config github-oauth.github.com $TRAVIS_GITHUB_TOKEN
+              env:
+                  SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                  SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+                  TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+
+            - name: 'Add Ibexa Rector dependency'
+              run: |
+                  # determine product version, fall back to ~5.0.x-dev if not possible  
+                  version='~'$(jq -r '.extra | ."branch-alias" | ."dev-main" // ."dev-master" // "5.0.x-dev"' < composer.json)
+                  composer require --dev --no-update ibexa/rector:"$version"
+
+            - name: 'Install Composer dependencies'
+              uses: ramsey/composer-install@v3
+              with:
+                  dependency-versions: highest
+
+            - name: 'Run rector'
+              run: vendor/bin/rector process --dry-run --ansi

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -31,12 +31,6 @@ jobs:
                   SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
                   TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
 
-            - name: 'Add Ibexa Rector dependency'
-              run: |
-                  # determine product version, fall back to ~5.0.x-dev if not possible  
-                  version='~'$(jq -r '.extra | ."branch-alias" | ."dev-main" // ."dev-master" // "5.0.x-dev"' < composer.json)
-                  composer require --dev --no-update ibexa/rector:"$version"
-
             - name: 'Install Composer dependencies'
               uses: ramsey/composer-install@v3
               with:


### PR DESCRIPTION
| :ticket: Issue | IBX-9627 |
|----------------|--------|

#### Related PRs:
- https://github.com/ibexa/rector/pull/24

#### Description:

Usage in packages' GHA CI configuration:

```yaml
jobs:
    rector:
        name: Run rector
        uses: ibexa/gh-workflows/.github/workflows/rector.yml@main
```

For closed-source packages that are required during composer install, you need to additionally pass Satis secrets, so the config would look like:

```yaml
jobs:
    rector:
        name: Run rector
        uses: ibexa/gh-workflows/.github/workflows/rector.yml@main
        secrets:
            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
```

`ibexa/rector:~5.0.x-dev` or `~4.6.x-dev` dependency needs to be added to each package's `composer.json`, along with generic `rector.php`:

```php
use Ibexa\Contracts\Rector\Factory\IbexaRectorConfigFactory;

return (new IbexaRectorConfigFactory(
    [
        __DIR__ . '/src',
        __DIR__ . '/tests',
    ]
))->createConfig();
```

Examples:
* OSS: https://github.com/ibexa/rest/pull/148
* DXP: https://github.com/ibexa/test-fixtures/pull/70