### PR TITLE
[Browser tests] Added slack notifications for setup jobs

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,7 +123,7 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
-            - if: always() && github.event_name != 'pull_request'
+            - if: always() && github.event_name == 'pull_request'
               name: Create Slack message variables
               run: |
                 echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -126,11 +126,11 @@ jobs:
             - if: always() && github.event_name == 'pull_request'
               name: Create Slack message variables
               run: |
-                echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
+                echo "RESULT_EMOJI=❌" >> $GITHUB_ENV
             - if: always() && job.status == 'success' && github.event_name == 'pull_request'
               name: Create Slack message success variables
               run: |
-                echo "RESULT_EMOJI=:white_check_mark:" >> $GITHUB_ENV
+                echo "RESULT_EMOJI=✅" >> $GITHUB_ENV
             - if: always() && github.event_name == 'pull_request'
               name: Create Slack message
               run: >

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,7 +123,7 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
-            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
+            - if: always() && github.event_name == 'pull_request' && (job.status == 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
               uses: slackapi/slack-github-action@v1.23.0
               with:

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -127,10 +127,6 @@ jobs:
               name: Create Slack message variables
               run: |
                 echo "RESULT_EMOJI=❌" >> $GITHUB_ENV
-            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
-              name: Create Slack message success variables
-              run: |
-                echo "RESULT_EMOJI=✅" >> $GITHUB_ENV
             - if: always() && github.event_name != 'pull_request'
               name: Create Slack message
               run: >
@@ -139,7 +135,7 @@ jobs:
                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
                 \"}}]}" >> $GITHUB_ENV
-            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
+            - if: always() && github.event_name != 'pull_request' && job.status != 'success' && job.status != 'skipped'
               name: Send notification about workflow result
               uses: slackapi/slack-github-action@v1.23.0
               with:

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,10 +123,18 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message variables
+              run: |
+                echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
+            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
+              name: Create Slack message success variables
+              run: |
+                echo "RESULT_EMOJI=:white_check_mark:" >> $GITHUB_ENV
             - if: always() && github.event_name == 'pull_request'
               name: Create Slack message
               run: >
-                echo "SLACK_PAYLOAD_SETUP=
+                echo "SLACK_PAYLOAD=
                 {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
@@ -135,7 +143,7 @@ jobs:
               name: Send notification about workflow result
               uses: slackapi/slack-github-action@v1.23.0
               with:
-                payload: ${{ env.SLACK_PAYLOAD_SETUP }}
+                payload: ${{ env.SLACK_PAYLOAD }}
               env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
                 SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,11 +123,19 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message
+              run: >
+                echo "SLACK_PAYLOAD_SETUP=
+                {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
+                $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
+                <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details> }}
+                \"}}]}" >> $GITHUB_ENV
             - if: always() && github.event_name == 'pull_request' && (job.status == 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
               uses: slackapi/slack-github-action@v1.23.0
               with:
-                payload: ${{ env.SLACK_PAYLOAD }}
+                payload: ${{ env.SLACK_PAYLOAD_SETUP }}
               env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
                 SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -127,7 +127,7 @@ jobs:
               name: Create Slack message variables
               run: |
                 echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
-            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
+            - if: always() && job.status == 'success' && github.event_name == 'pull_request'
               name: Create Slack message success variables
               run: |
                 echo "RESULT_EMOJI=:white_check_mark:" >> $GITHUB_ENV

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,6 +123,14 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
+            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
+              name: Send notification about workflow result
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                payload: ${{ env.SLACK_PAYLOAD }}
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     browser-tests:
         needs: setup-jobs

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,7 +123,7 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
-            - if: always() && github.event_name != 'pull_request'
+            - if: always() && github.event_name == 'pull_request'
               name: Create Slack message
               run: >
                 echo "SLACK_PAYLOAD_SETUP=

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,15 +123,15 @@ jobs:
                 matrix=$(php -r 'echo json_encode(["offset" => range(0, ${{ env.job_count }} - 1)]);')
                 echo "matrix=$matrix" >> $GITHUB_OUTPUT
                 echo "job-count=$job_count" >> $GITHUB_OUTPUT
-            - if: always() && github.event_name == 'pull_request'
+            - if: always() && github.event_name != 'pull_request'
               name: Create Slack message variables
               run: |
                 echo "RESULT_EMOJI=❌" >> $GITHUB_ENV
-            - if: always() && job.status == 'success' && github.event_name == 'pull_request'
+            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
               name: Create Slack message success variables
               run: |
                 echo "RESULT_EMOJI=✅" >> $GITHUB_ENV
-            - if: always() && github.event_name == 'pull_request'
+            - if: always() && github.event_name != 'pull_request'
               name: Create Slack message
               run: >
                 echo "SLACK_PAYLOAD=
@@ -139,7 +139,7 @@ jobs:
                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
                 \"}}]}" >> $GITHUB_ENV
-            - if: always() && github.event_name == 'pull_request' && (job.status == 'success' || inputs.send-success-notification)
+            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
               uses: slackapi/slack-github-action@v1.23.0
               with:

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -129,7 +129,7 @@ jobs:
                 echo "SLACK_PAYLOAD_SETUP=
                 {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
-                <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details> }}
+                <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
                 \"}}]}" >> $GITHUB_ENV
             - if: always() && github.event_name == 'pull_request' && (job.status == 'success' || inputs.send-success-notification)
               name: Send notification about workflow result


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Added slack notifications to `monitoring-github-ci` channel for setup jobs also. Previously only browser tests jobs were covered.

Rationale: Sometimes in nightly regressions some builds fail on setup jobs level. Such failures are not visible on the slack channel. With this change it will be easier to spot them.

Notifications for setup jobs are only allowed for failure or cancelled job statuses.

Example test success notification from below test PR (served only as confirmation it works):

![Screenshot 2025-03-10 at 14 19 11](https://github.com/user-attachments/assets/ab8bba44-8294-4dc4-93c1-fe2cd0c67f08)
ref. https://ibexa.slack.com/archives/C06GUKQSMPB/p1741356986934899

#### For QA:
Tested in https://github.com/ibexa/oss/pull/207.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
