### PR TITLE
IBX-8471: [Browser tests] Configured `APP_SECRET` for Behat tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -92,6 +92,7 @@ on:
 env:
     APP_ENV: behat
     APP_DEBUG: 1
+    APP_SECRET: '$ecretf0rt3st'
     PHP_INI_ENV_memory_limit: 512M
     COMPOSER_CACHE_DIR: ~/.composer/cache
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8471 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/http-cache/pull/68
- https://github.com/ibexa/recipes-dev/pull/175
- https://github.com/ibexa/docker/pull/40

#### Description:

Alternative to https://github.com/ibexa/recipes-dev/pull/175. Added `APP_SECRET` to GHA job env variables instead of installing it through recipes. Requires https://github.com/ibexa/docker/pull/40.

See https://github.com/ibexa/recipes-dev/pull/175 for more details on the issue at hand.