### PR TITLE
IBX-8471: [Browser tests] Made `APP_SECRET` longer for JWT

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -92,7 +92,7 @@ on:
 env:
     APP_ENV: behat
     APP_DEBUG: 1
-    APP_SECRET: '$ecretf0rt3st'
+    APP_SECRET: '2d4218d7b6c69a9f88da7b8986e64717b3c40948a7ba2b1ca309dc292472286d'
     PHP_INI_ENV_memory_limit: 512M
     COMPOSER_CACHE_DIR: ~/.composer/cache
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8471 |
|----------------|-----------------------|

#### Related PRs: 
- #61


#### Description:

Looks like [`APP_SECRET` needs to be longer for JWT to work properly](https://github.com/lexik/LexikJWTAuthenticationBundle/issues/1063#issuecomment-1229897168).

Too short `APP_SECRET` causes [this PB issue](https://github.com/ibexa/page-builder/actions/runs/15067260858/job/42354807284#step:18:93).

My local tests show that 32 characters is enough [1], but following the issue linked above, I've made it 64 just to be safe.

[1] That's why I couldn't reproduce it locally.

#### For QA:

Occurs only for regression tests setup.