### PR TITLE
Bump default image to PHP 8.3 & Node 22

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -34,7 +34,7 @@ on:
                 required: false
                 type: boolean
             php-image:
-                default: "ghcr.io/ibexa/docker/php:8.3-node18"
+                default: "ghcr.io/ibexa/docker/php:8.3-node22"
                 description: "The PHP image to use"
                 required: false
                 type: string


### PR DESCRIPTION
| :ticket: Issue | IBX-9916 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Bumping default image to PHP 8.3 & Node 22

Changing Node version only here. Needed for the sake of 5.0 after CKE 45 merge.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->

#### TODO:
- [ ] Set explicit `php-image` for matchers on v3.3 in Experience?

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
