### PR TITLE
IBX-9916: Set NODE_OPTIONS inline for both tests setup phases

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -291,33 +291,27 @@ jobs:
                 # Reinstall database using the new repository
                 docker compose exec -T --user www-data app sh -c "php bin/console ibexa:install --no-interaction"
 
-            - if: inputs.test-setup-phase-1 != '' && contains(steps.project-version.outputs.version, '5.0.x-dev')
-              name: Run first phase of tests setup
-              run: |
-                  cd ${HOME}/build/project
-                  docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
-                  docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
-
-            - if: inputs.test-setup-phase-1 != '' && !contains(steps.project-version.outputs.version, '5.0.x-dev')
+            - if: inputs.test-setup-phase-1 != ''
               name: Run first phase of tests setup
               run: |
                 cd ${HOME}/build/project
                 docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
-                docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                if [[ "${{ steps.project-version.outputs.version }}" == *'5.0.x-dev'* ]]; then
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
+                else
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                fi
 
-            - if: inputs.test-setup-phase-2 != '' && contains(steps.project-version.outputs.version, '5.0.x-dev')
+            - if: inputs.test-setup-phase-2 != ''
               name: Run second phase of tests setup
               run: |
                 cd ${HOME}/build/project
                 docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
-                docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
-
-            - if: inputs.test-setup-phase-2 != '' && !contains(steps.project-version.outputs.version, '5.0.x-dev')
-              name: Run second phase of tests setup
-              run: |
-                  cd ${HOME}/build/project
-                  docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
+                if [[ "${{ steps.project-version.outputs.version }}" == *'5.0.x-dev'* ]]; then
+                  docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
+                else
                   docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                fi
 
             - name: Run tests
               run: |


### PR DESCRIPTION
| :ticket: Issue | IBX-9916 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/ci-scripts/pull/106


#### Description:
Twin PR to the one in ibexa/ci-scripts.

"Run first phase of tests setup" & "Run second phase of tests setup" are executed via this repo.

Discovered & tested in https://github.com/ibexa/site-factory/pull/127.
Ref. https://github.com/ibexa/site-factory/actions/runs/15272725853/job/42954670434?pr=127#step:16:147.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
