### PR TITLE
IBX-11717: [GHA] Prepared Ibexa `composer-audit-ignore` action

### DIFF
--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -37,7 +37,8 @@ runs:
                     PKSA-2wrf-1xmk-1pky \
                     PKSA-6319-ffpf-gx66 \
                     PKSA-n7sg-8f52-pqtf \
-                    PKSA-8kk8-h2xr-h5nx
+                    PKSA-8kk8-h2xr-h5nx \
+                    PKSA-2rbx-bjdx-4d4d
                 do
                     composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
                 done

--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -1,0 +1,26 @@
+name: "Configure ignoring known unsolvable advisories"
+author: 'Ibexa AS'
+description: >-
+    Configures Composer `audit.ignore` list for CI tests in an allow-list way.
+
+inputs:
+    php-version:
+        description: 'PHP version'
+        required: true
+
+runs:
+    using: "composite"
+    steps:
+        -   if: startsWith(inputs.php-version, '7.4.')
+            name: Configure advisory ignore list for PHP 7.4
+            shell: bash
+            run: |
+                reason="The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8"
+
+                for advisory in \
+                    PKSA-xwpn-zs9j-6wy5 \
+                    PKSA-sf9j-1gs7-xzvx \
+                    PKSA-7h5p-prw9-w5nr
+                do
+                    composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
+                done

--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -20,7 +20,24 @@ runs:
                 for advisory in \
                     PKSA-xwpn-zs9j-6wy5 \
                     PKSA-sf9j-1gs7-xzvx \
-                    PKSA-7h5p-prw9-w5nr
+                    PKSA-7h5p-prw9-w5nr \
+                    PKSA-5k7f-wvjj-jrgw \
+                    PKSA-sjvz-tbbr-vwth \
+                    PKSA-h8hf-ytnd-5t9q \
+                    PKSA-wwb1-81rc-pd65 \
+                    PKSA-hgmw-wn4d-hpcy \
+                    PKSA-kvv6-36cr-fkzb \
+                    PKSA-n14z-jjjg-g8vd \
+                    PKSA-3mcc-k66d-pydb \
+                    PKSA-gw7n-z4yx-7xjt \
+                    PKSA-dpx1-78wg-1kqs \
+                    PKSA-21g2-dzjv-sky5 \
+                    PKSA-v3kg-5xkr-pykw \
+                    PKSA-yhcn-xrg3-68b1 \
+                    PKSA-2wrf-1xmk-1pky \
+                    PKSA-6319-ffpf-gx66 \
+                    PKSA-n7sg-8f52-pqtf \
+                    PKSA-8kk8-h2xr-h5nx
                 do
                     composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
                 done

--- a/actions/composer-install/action.yml
+++ b/actions/composer-install/action.yml
@@ -73,7 +73,7 @@ runs:
             env:
                 GITHUB_ACTION_PATH: ${{ github.action_path }}
 
-        -   uses: ramsey/composer-install@v3
+        -   uses: ramsey/composer-install@v4
             with:
                 dependency-versions: highest
                 composer-options: ${{ inputs.composer-options }}

--- a/actions/composer-install/action.yml
+++ b/actions/composer-install/action.yml
@@ -42,6 +42,7 @@ runs:
 
         -   name: Setup PHP Action
             uses: shivammathur/setup-php@v2
+            id: setup_php
             with:
                 php-version: ${{ matrix.php }}
                 coverage: ${{ inputs.coverage }}
@@ -72,6 +73,11 @@ runs:
                 fi
             env:
                 GITHUB_ACTION_PATH: ${{ github.action_path }}
+
+        -   name: 'Ignore known unsolvable advisories'
+            uses: ibexa/gh-workflows/actions/composer-audit-ignore@main
+            with:
+                php-version: ${{ steps.setup_php.outputs.php-version }}
 
         -   uses: ramsey/composer-install@v4
             with:


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-11717, IBX-11797 |
|----------------|-----------|


#### Related PRs: 
- ibexa/ci-scripts#137


#### Description:

Defined `ibexa/gh-workflows/actions/composer-audit-ignore` GHA and used it in `ibexa/gh-workflows/actions/composer-install` action.

ATM it ignores specific advisories for PHP 7.4-only, as described in ibexa/ci-scripts#137

#### For QA:

No QA required.

#### Documentation:

Already documented.