### PR TITLE
IBX-11797: Added missing `twig/*` advisories & included PHP 8.0 

### DIFF
--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -12,15 +12,28 @@ runs:
     using: "composite"
     steps:
         -   if: startsWith(inputs.php-version, '7.4.')
-            name: Configure advisory ignore list for PHP 7.4
+            name: Configure PHP 7.4-only advisory ignore list
             shell: bash
             run: |
-                reason="The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8"
+                reason="The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8.1+"
 
                 for advisory in \
                     PKSA-xwpn-zs9j-6wy5 \
                     PKSA-sf9j-1gs7-xzvx \
-                    PKSA-7h5p-prw9-w5nr \
+                    PKSA-7h5p-prw9-w5nr
+                do
+                    composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
+                done
+
+        -   if: startsWith(inputs.php-version, '7.4.') || startsWith(inputs.php-version, '8.0.')
+            name: Configure shared advisory ignore list for PHP 7.4 and 8.0
+            env:
+                PHP_VERSION: ${{ inputs.php-version }}
+            shell: bash
+            run: |
+                reason="The affected version of 3rd party component is installed on PHP ${PHP_VERSION%.*}. There's no alternative supporting PHP ${PHP_VERSION%.*}. Consider upgrading to PHP 8.1+"
+
+                for advisory in \
                     PKSA-5k7f-wvjj-jrgw \
                     PKSA-sjvz-tbbr-vwth \
                     PKSA-h8hf-ytnd-5t9q \

--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -38,7 +38,8 @@ runs:
                     PKSA-6319-ffpf-gx66 \
                     PKSA-n7sg-8f52-pqtf \
                     PKSA-8kk8-h2xr-h5nx \
-                    PKSA-2rbx-bjdx-4d4d
+                    PKSA-2rbx-bjdx-4d4d \
+                    PKSA-fs5b-x5k4-1h39
                 do
                     composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
                 done


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-11797 |
|----------------|-----------|

 
#### Related PRs: 
- #96

#### Description:

I missed the fact that `twig/*` advisories apply to both PHP 7.4 and 8.0, because `twig/*:v3.26.0` supports PHP >=8.1

Also added [PKSA-fs5b-x5k4-1h39](https://packagist.org/security-advisories/PKSA-fs5b-x5k4-1h39) for `twig/cssinliner-extra`, which I initially missed. 

Now it should include all 19 advisories as declared in [the Symfony blog post](https://symfony.com/blog/claude-mythos-audited-symfony-and-found-19-vulnerabilities).  

#### For QA:
No QA required - applies to Backend CI jobs.