### PR TITLE
[DON'T MERGE - POC] IBX-11740: Added playwright-browser-tests.yml

### DIFF
--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -332,6 +332,9 @@ jobs:
             - name: Run Playwright tests
               run: |
                 cd ${HOME}/build/project
+                echo "=== Playwright spec files found in vendor ==="
+                find vendor/ibexa -name "*.spec.ts" -path "*/playwright_ts/tests/*" 2>/dev/null || echo "None found"
+                echo "=== Running Playwright ==="
                 /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -315,18 +315,22 @@ jobs:
                 });
                 EOF
                 npm install --prefix /tmp/playwright-tools --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
+                # Symlink Playwright packages into project root node_modules so esbuild can resolve them
+                # when transforming spec files in vendor/ibexa/*/tests/playwright_ts/tests/
+                TOOLS="/tmp/playwright-tools/node_modules"
+                mkdir -p node_modules/@playwright node_modules/@ibexa
+                ln -sf "$TOOLS/@playwright/test"              node_modules/@playwright/test
+                ln -sf "$TOOLS/playwright"                    node_modules/playwright
+                ln -sf "$TOOLS/@ibexa/cohesivo-playwright"   node_modules/@ibexa/cohesivo-playwright
 
             - name: Install Playwright browsers
               run: |
-                export PATH="/tmp/playwright-tools/node_modules/.bin:$PATH"
-                playwright install --with-deps chromium
+                /tmp/playwright-tools/node_modules/.bin/playwright install --with-deps chromium
 
             - name: Run Playwright tests
               run: |
                 cd ${HOME}/build/project
-                export PATH="/tmp/playwright-tools/node_modules/.bin:$PATH"
-                export NODE_PATH="/tmp/playwright-tools/node_modules"
-                playwright test ${{ inputs.test-suite }}
+                /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080
                 DOCKER_COMPOSE_ENV_FILE: ${{ env.HOME }}/build/project/.env

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -314,17 +314,19 @@ jobs:
                   ],
                 });
                 EOF
-                npm install --no-save --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
+                npm install --prefix /tmp/playwright-tools --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
 
             - name: Install Playwright browsers
               run: |
-                cd ${HOME}/build/project
-                npx playwright install --with-deps chromium
+                export PATH="/tmp/playwright-tools/node_modules/.bin:$PATH"
+                playwright install --with-deps chromium
 
             - name: Run Playwright tests
               run: |
                 cd ${HOME}/build/project
-                npx playwright test ${{ inputs.test-suite }}
+                export PATH="/tmp/playwright-tools/node_modules/.bin:$PATH"
+                export NODE_PATH="/tmp/playwright-tools/node_modules"
+                playwright test ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080
                 DOCKER_COMPOSE_ENV_FILE: ${{ env.HOME }}/build/project/.env

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -285,10 +285,10 @@ jobs:
                 import { defineConfig, devices } from '@playwright/test';
 
                 const baseURL = process.env.APP_URL ?? 'http://localhost:8080';
-                const vendorTests = '**/vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts';
 
                 export default defineConfig({
-                  testMatch: vendorTests,
+                  testDir: './vendor/ibexa',
+                  testMatch: /playwright_ts\/tests\/.*\.spec\.ts/,
                   globalSetup: './playwright-global-setup.ts',
                   fullyParallel: false,
                   forbidOnly: !!process.env.CI,
@@ -325,6 +325,8 @@ jobs:
                   ],
                 });
                 EOF
+                echo "=== playwright.config.ts content ==="
+                cat playwright.config.ts
                 npm install --prefix /tmp/playwright-tools --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
 
             - name: Install Playwright browsers

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -272,8 +272,11 @@ jobs:
                     await page.keyboard.press('Tab');
                     await page.locator('button[type="submit"].ibexa-login__btn--sign-in').waitFor({ state: 'visible', timeout: 10_000 });
                     await page.locator('button[type="submit"].ibexa-login__btn--sign-in').click();
+                    await page.waitForURL('**/admin/**', { timeout: 60_000 });
                     await page.waitForLoadState('networkidle');
+                    console.log('Login successful, current URL:', page.url());
                     await context.storageState({ path: './playwright-auth.json' });
+                    console.log('Auth state saved to playwright-auth.json');
                   } finally {
                     await context.close();
                     await browser.close();
@@ -294,7 +297,10 @@ jobs:
                   forbidOnly: !!process.env.CI,
                   retries: process.env.CI ? 1 : 0,
                   workers: process.env.CI ? 1 : undefined,
-                  reporter: process.env.CI ? 'github' : 'html',
+                  timeout: 10_000,
+                  reporter: process.env.CI
+                    ? [['github'], ['html', { open: 'never', outputFolder: './playwright-report' }]]
+                    : [['html']],
                   use: {
                     baseURL,
                     storageState: './playwright-auth.json',

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -270,7 +270,7 @@ jobs:
                 import { defineConfig, devices } from '@playwright/test';
 
                 const baseURL = process.env.APP_URL ?? 'http://localhost:8080';
-                const vendorTests = 'vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts';
+                const vendorTests = '**/vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts';
 
                 export default defineConfig({
                   testMatch: vendorTests,
@@ -319,9 +319,10 @@ jobs:
                 # when transforming spec files in vendor/ibexa/*/tests/playwright_ts/tests/
                 TOOLS="/tmp/playwright-tools/node_modules"
                 mkdir -p node_modules/@playwright node_modules/@ibexa
-                ln -sf "$TOOLS/@playwright/test"              node_modules/@playwright/test
-                ln -sf "$TOOLS/playwright"                    node_modules/playwright
-                ln -sf "$TOOLS/@ibexa/cohesivo-playwright"   node_modules/@ibexa/cohesivo-playwright
+                rm -rf node_modules/@playwright/test node_modules/playwright node_modules/@ibexa/cohesivo-playwright
+                ln -s "$TOOLS/@playwright/test"            node_modules/@playwright/test
+                ln -s "$TOOLS/playwright"                  node_modules/playwright
+                ln -s "$TOOLS/@ibexa/cohesivo-playwright"  node_modules/@ibexa/cohesivo-playwright
 
             - name: Install Playwright browsers
               run: |
@@ -333,7 +334,7 @@ jobs:
                 /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080
-                DOCKER_COMPOSE_ENV_FILE: ${{ env.HOME }}/build/project/.env
+                DOCKER_COMPOSE_ENV_FILE: /home/runner/build/project/.env
                 ADMIN_LOGIN: admin
                 ADMIN_PASSWORD: publish
                 CI: true
@@ -343,7 +344,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: playwright-report-${{ inputs.project-edition }}
-                  path: ${{ env.HOME }}/build/project/playwright-report/
+                  path: /home/runner/build/project/playwright-report/
                   retention-days: 14
 
             - if: always() && github.event_name != 'pull_request'

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -325,9 +325,13 @@ jobs:
                   ],
                 });
                 EOF
-                echo "=== playwright.config.ts content ==="
-                cat playwright.config.ts
                 npm install --prefix /tmp/playwright-tools --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
+                mkdir -p node_modules/@playwright
+                ln -sf /tmp/playwright-tools/node_modules/@playwright/test node_modules/@playwright/test
+                ln -sf /tmp/playwright-tools/node_modules/playwright node_modules/playwright
+                for dir in vendor/ibexa/*/tests/playwright_ts/node_modules; do
+                  [ -d "$dir" ] && rm -rf "$dir/playwright" "$dir/@playwright" 2>/dev/null || true
+                done
 
             - name: Install Playwright browsers
               run: |

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -314,7 +314,7 @@ jobs:
                   ],
                 });
                 EOF
-                npm install --no-save @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
+                npm install --no-save --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
 
             - name: Install Playwright browsers
               run: |

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -1,0 +1,225 @@
+name: Browser tests (Playwright)
+
+on:
+    workflow_call:
+        inputs:
+            project-edition:
+                description: "Project edition to set up: oss, headless, experience, commerce"
+                required: true
+                type: string
+            test-suite:
+                description: "Playwright CLI args (e.g. --project=commerce)"
+                required: true
+                type: string
+            project-version:
+                description: "Project version (e.g. 6.0.x-dev). If empty, inferred from branch alias."
+                required: false
+                type: string
+                default: ''
+            setup:
+                description: "Docker Compose files to use"
+                required: false
+                type: string
+                default: "doc/docker/base-dev.yml"
+            php-image:
+                description: "PHP Docker image to use"
+                required: false
+                type: string
+                default: "ghcr.io/ibexa/docker/php:8.3-node22"
+            node-version:
+                description: "Node.js version for running Playwright"
+                required: false
+                type: string
+                default: "20"
+            ci-scripts-branch:
+                description: "Branch from ibexa/ci-scripts to use"
+                required: false
+                type: string
+                default: "main"
+            test-setup-phase-1:
+                description: "Behat suite to run before Playwright tests for data seeding - phase 1"
+                required: false
+                type: string
+                default: ""
+            test-setup-phase-2:
+                description: "Behat suite to run before Playwright tests for data seeding - phase 2"
+                required: false
+                type: string
+                default: ""
+            send-success-notification:
+                description: "Send a Slack notification when tests pass"
+                required: false
+                type: boolean
+                default: true
+            timeout:
+                description: "Job timeout in minutes"
+                required: false
+                type: number
+                default: 60
+        secrets:
+            SLACK_WEBHOOK_URL:
+                required: false
+            SATIS_NETWORK_KEY:
+                required: false
+            SATIS_NETWORK_TOKEN:
+                required: false
+            AUTOMATION_CLIENT_ID:
+                required: false
+            AUTOMATION_CLIENT_SECRET:
+                required: false
+            EZROBOT_33:
+                required: false
+
+env:
+    APP_ENV: behat
+    APP_DEBUG: 1
+    APP_SECRET: '2d4218d7b6c69a9f88da7b8986e64717b3c40948a7ba2b1ca309dc292472286d'
+    PHP_INI_ENV_memory_limit: 1G
+    COMPOSER_CACHE_DIR: ~/.composer/cache
+
+jobs:
+    browser-tests:
+        runs-on: ubuntu-latest
+        timeout-minutes: ${{ inputs.timeout }}
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up project version
+              id: project-version
+              run: |
+                if [[ "$version" == "" ]] ; then
+                    echo "Input project version not set, taking the value from composer.json"
+                    version=$(cat composer.json | jq -r '.extra | ."branch-alias" | .[]')
+                fi
+                if [[ "$version" == "3.3.x-dev" ]] ; then
+                    version="^3.3.x-dev"
+                fi
+                echo "version=$version" >> $GITHUB_OUTPUT
+              env:
+                version: ${{ inputs.project-version }}
+
+            - name: Setup PHP Action
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.3
+                  coverage: none
+
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ env.COMPOSER_CACHE_DIR }}
+                  key: ${{ inputs.project-edition }}-${{ steps.project-version.outputs.version }}-${{ inputs.php-image }}-${{ github.sha }}
+                  restore-keys: |
+                    ${{ inputs.project-edition }}-${{ steps.project-version.outputs.version }}-${{ inputs.php-image }}
+
+            - name: Generate token
+              id: generate_token
+              uses: actions/create-github-app-token@v2
+              with:
+                  app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                  private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                  owner: ibexa
+
+            - if: env.SATIS_NETWORK_KEY != ''
+              name: Add composer keys for private packagist
+              run: |
+                  composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
+              env:
+                  SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+                  SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+
+            - name: Add composer key for GitHub App
+              if: ${{ steps.generate_token.outputs.token != '' }}
+              run: |
+                  composer config github-oauth.github.com $GITHUB_TOKEN
+              env:
+                  GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+            - if: startsWith(steps.project-version.outputs.version, 'v') == false
+              name: Set up whole project using the tested dependency (dev version)
+              run: |
+                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/${{ steps.project-version.outputs.version }}/prepare_project_edition.sh" > prepare_project_edition.sh
+                chmod +x prepare_project_edition.sh
+                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ steps.project-version.outputs.version }} ${{ inputs.setup }} ${{ inputs.php-image }}
+
+            - if: startsWith(steps.project-version.outputs.version, 'v')
+              name: Set up whole project using a stable release
+              run: |
+                curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-branch }}/bin/stable/prepare_project_edition.sh" > prepare_project_edition.sh
+                chmod +x prepare_project_edition.sh
+                ./prepare_project_edition.sh ${{ inputs.project-edition }} ${{ steps.project-version.outputs.version }} ${{ inputs.setup }} ${{ inputs.php-image }}
+
+            - name: Add ibexa_integrated_help config
+              if: inputs.project-edition != 'oss'
+              run: |
+                cd ${HOME}/build/project
+                docker compose --env-file=.env exec -T --user www-data app sh -c "printf 'ibexa_integrated_help:\n    enabled: false\n' > config/packages/ibexa_integrated_help.yaml"
+
+            - if: inputs.test-setup-phase-1 != ''
+              name: Run first phase of tests setup
+              run: |
+                cd ${HOME}/build/project
+                docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
+                docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+
+            - if: inputs.test-setup-phase-2 != ''
+              name: Run second phase of tests setup
+              run: |
+                cd ${HOME}/build/project
+                docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
+                docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+                  cache: 'npm'
+
+            - name: Install Node.js dependencies
+              run: npm ci
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Run Playwright tests
+              run: npx playwright test ${{ inputs.test-suite }}
+              env:
+                APP_URL: http://localhost:8080
+                CI: true
+
+            - name: Upload Playwright report
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report-${{ inputs.project-edition }}
+                  path: playwright-report/
+                  retention-days: 14
+
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message variables
+              run: |
+                echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
+
+            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
+              name: Create Slack message success variables
+              run: |
+                echo "RESULT_EMOJI=:white_check_mark:" >> $GITHUB_ENV
+
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message
+              run: >
+                 echo "SLACK_PAYLOAD=
+                 {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
+                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
+                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
+                 \"}}]}" >> $GITHUB_ENV
+
+            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
+              name: Send notification about workflow result
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: ${{ env.SLACK_PAYLOAD }}
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -30,7 +30,7 @@ on:
                 description: "Node.js version for running Playwright"
                 required: false
                 type: string
-                default: "20"
+                default: "22"
             ci-scripts-branch:
                 description: "Branch from ibexa/ci-scripts to use"
                 required: false
@@ -174,18 +174,137 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: ${{ inputs.node-version }}
-                  cache: 'npm'
 
-            - name: Install Node.js dependencies
-              run: npm ci
+            # Inject playwright.config.ts and playwright-global-setup.ts into the installed project.
+            # testMatch discovers tests shipped by all installed Ibexa packages
+            # under vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts
+            - name: Inject Playwright config into installed project
+              run: |
+                cd ${HOME}/build/project
+                cat > playwright-global-setup.ts << 'EOF'
+                import { chromium } from '@playwright/test';
+                import { execSync } from 'child_process';
+                import { globSync } from 'fs';
+                import path from 'path';
+
+                export default async function globalSetup(): Promise<void> {
+                  const projectRoot = process.cwd();
+                  const dockerEnvFile = process.env.DOCKER_COMPOSE_ENV_FILE;
+
+                  // Run migration YAML files from all installed Ibexa packages
+                  const migrationFiles = globSync('vendor/ibexa/*/tests/playwright_ts/migrations/*.yaml');
+                  for (const migrationFile of migrationFiles) {
+                    const absPath = path.resolve(projectRoot, migrationFile);
+                    try {
+                      if (dockerEnvFile) {
+                        const containerPath = absPath.replace(projectRoot, '/var/www');
+                        execSync(
+                          `docker compose --env-file="${dockerEnvFile}" exec -T --user www-data app sh -c "php bin/console ibexa:migrations:import '${containerPath}' --no-interaction && php bin/console ibexa:migrations:migrate --no-interaction"`,
+                          { cwd: projectRoot, stdio: 'inherit' },
+                        );
+                      } else {
+                        execSync(
+                          `php bin/console ibexa:migrations:import "${absPath}" --no-interaction && php bin/console ibexa:migrations:migrate --no-interaction`,
+                          { cwd: projectRoot, stdio: 'inherit' },
+                        );
+                      }
+                    } catch {
+                      // migration already executed or non-fatal — continue
+                    }
+                  }
+
+                  // One-time browser login — saves session to playwright-auth.json
+                  const baseURL = process.env.APP_URL ?? 'http://localhost:8080';
+                  const adminUser = process.env.ADMIN_LOGIN ?? 'admin';
+                  const adminPassword = process.env.ADMIN_PASSWORD ?? 'publish';
+
+                  const browser = await chromium.launch({ headless: true });
+                  const context = await browser.newContext({ baseURL, locale: 'en-GB' });
+                  const page = await context.newPage();
+
+                  try {
+                    await page.goto('/admin/login');
+                    await page.waitForLoadState('domcontentloaded');
+                    await page.locator('#username').waitFor({ state: 'visible', timeout: 30_000 });
+                    await page.locator('#username').pressSequentially(adminUser);
+                    await page.keyboard.press('Tab');
+                    await page.locator('#password').pressSequentially(adminPassword);
+                    await page.keyboard.press('Tab');
+                    await page.locator('button[type="submit"].ibexa-login__btn--sign-in').waitFor({ state: 'visible', timeout: 10_000 });
+                    await page.locator('button[type="submit"].ibexa-login__btn--sign-in').click();
+                    await page.waitForLoadState('networkidle');
+                    await context.storageState({ path: './playwright-auth.json' });
+                  } finally {
+                    await context.close();
+                    await browser.close();
+                  }
+                }
+                EOF
+
+                cat > playwright.config.ts << 'EOF'
+                import { defineConfig, devices } from '@playwright/test';
+
+                const baseURL = process.env.APP_URL ?? 'http://localhost:8080';
+                const vendorTests = 'vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts';
+
+                export default defineConfig({
+                  testMatch: vendorTests,
+                  globalSetup: './playwright-global-setup.ts',
+                  fullyParallel: false,
+                  forbidOnly: !!process.env.CI,
+                  retries: process.env.CI ? 1 : 0,
+                  workers: process.env.CI ? 1 : undefined,
+                  reporter: process.env.CI ? 'github' : 'html',
+                  use: {
+                    baseURL,
+                    storageState: './playwright-auth.json',
+                    locale: 'en-GB',
+                    ignoreHTTPSErrors: true,
+                    trace: 'retain-on-failure',
+                    screenshot: 'only-on-failure',
+                    video: 'on-first-retry',
+                    viewport: { width: 1920, height: 1080 },
+                  },
+                  projects: [
+                    {
+                      name: 'oss',
+                      grep: /@IbexaOSS/,
+                      use: { ...devices['Desktop Chrome'] },
+                    },
+                    {
+                      name: 'headless',
+                      grep: /@IbexaHeadless/,
+                      use: { ...devices['Desktop Chrome'] },
+                    },
+                    {
+                      name: 'experience',
+                      grep: /@IbexaExperience/,
+                      use: { ...devices['Desktop Chrome'] },
+                    },
+                    {
+                      name: 'commerce',
+                      grep: /@IbexaCommerce/,
+                      use: { ...devices['Desktop Chrome'] },
+                    },
+                  ],
+                });
+                EOF
+                npm install --no-save @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@github:ibexa/cohesivo-playwright#main
 
             - name: Install Playwright browsers
-              run: npx playwright install --with-deps chromium
+              run: |
+                cd ${HOME}/build/project
+                npx playwright install --with-deps chromium
 
             - name: Run Playwright tests
-              run: npx playwright test ${{ inputs.test-suite }}
+              run: |
+                cd ${HOME}/build/project
+                npx playwright test ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080
+                DOCKER_COMPOSE_ENV_FILE: ${{ env.HOME }}/build/project/.env
+                ADMIN_LOGIN: admin
+                ADMIN_PASSWORD: publish
                 CI: true
 
             - name: Upload Playwright report
@@ -193,7 +312,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: playwright-report-${{ inputs.project-edition }}
-                  path: playwright-report/
+                  path: ${{ env.HOME }}/build/project/playwright-report/
                   retention-days: 14
 
             - if: always() && github.event_name != 'pull_request'

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -187,6 +187,15 @@ jobs:
             - name: Fix write permissions on project directory
               run: sudo chmod -R a+rwX ${HOME}/build/project
 
+            - name: Install npm dependencies in Playwright test directories
+              run: |
+                for dir in ${HOME}/build/project/vendor/ibexa/*/tests/playwright_ts; do
+                  if [ -f "$dir/package.json" ]; then
+                    echo "→ npm ci in $dir"
+                    cd "$dir" && npm ci
+                  fi
+                done
+
             # Inject playwright.config.ts and playwright-global-setup.ts into the installed project.
             # testMatch discovers tests shipped by all installed Ibexa packages
             # under vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts
@@ -315,14 +324,6 @@ jobs:
                 });
                 EOF
                 npm install --prefix /tmp/playwright-tools --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
-                # Symlink Playwright packages into project root node_modules so esbuild can resolve them
-                # when transforming spec files in vendor/ibexa/*/tests/playwright_ts/tests/
-                TOOLS="/tmp/playwright-tools/node_modules"
-                mkdir -p node_modules/@playwright node_modules/@ibexa
-                rm -rf node_modules/@playwright/test node_modules/playwright node_modules/@ibexa/cohesivo-playwright
-                ln -s "$TOOLS/@playwright/test"            node_modules/@playwright/test
-                ln -s "$TOOLS/playwright"                  node_modules/playwright
-                ln -s "$TOOLS/@ibexa/cohesivo-playwright"  node_modules/@ibexa/cohesivo-playwright
 
             - name: Install Playwright browsers
               run: |

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -308,22 +308,18 @@ jobs:
                   projects: [
                     {
                       name: 'oss',
-                      grep: /@IbexaOSS/,
                       use: { ...devices['Desktop Chrome'] },
                     },
                     {
                       name: 'headless',
-                      grep: /@IbexaHeadless/,
                       use: { ...devices['Desktop Chrome'] },
                     },
                     {
                       name: 'experience',
-                      grep: /@IbexaExperience/,
                       use: { ...devices['Desktop Chrome'] },
                     },
                     {
                       name: 'commerce',
-                      grep: /@IbexaCommerce/,
                       use: { ...devices['Desktop Chrome'] },
                     },
                   ],

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -185,7 +185,7 @@ jobs:
                 GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
             - name: Fix write permissions on project directory
-              run: sudo chmod -R a+w ${HOME}/build/project
+              run: sudo chmod -R a+rwX ${HOME}/build/project
 
             # Inject playwright.config.ts and playwright-global-setup.ts into the installed project.
             # testMatch discovers tests shipped by all installed Ibexa packages

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -175,6 +175,14 @@ jobs:
               with:
                   node-version: ${{ inputs.node-version }}
 
+            - name: Configure npm to use HTTPS for GitHub packages
+              if: ${{ steps.generate_token.outputs.token != '' }}
+              run: |
+                git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
+                git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+              env:
+                GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
             # Inject playwright.config.ts and playwright-global-setup.ts into the installed project.
             # testMatch discovers tests shipped by all installed Ibexa packages
             # under vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts
@@ -183,18 +191,31 @@ jobs:
                 cd ${HOME}/build/project
                 cat > playwright-global-setup.ts << 'EOF'
                 import { chromium } from '@playwright/test';
-                import { execSync } from 'child_process';
-                import { globSync } from 'fs';
+                import { execSync, execFileSync } from 'child_process';
                 import path from 'path';
+                import fs from 'fs';
 
                 export default async function globalSetup(): Promise<void> {
                   const projectRoot = process.cwd();
                   const dockerEnvFile = process.env.DOCKER_COMPOSE_ENV_FILE;
 
-                  // Run migration YAML files from all installed Ibexa packages
-                  const migrationFiles = globSync('vendor/ibexa/*/tests/playwright_ts/migrations/*.yaml');
-                  for (const migrationFile of migrationFiles) {
-                    const absPath = path.resolve(projectRoot, migrationFile);
+                  // Discover migration YAML files from all installed Ibexa packages
+                  const migrationFiles: string[] = [];
+                  const vendorIbexa = path.join(projectRoot, 'vendor', 'ibexa');
+                  if (fs.existsSync(vendorIbexa)) {
+                    for (const pkg of fs.readdirSync(vendorIbexa)) {
+                      const migrationsDir = path.join(vendorIbexa, pkg, 'tests', 'playwright_ts', 'migrations');
+                      if (fs.existsSync(migrationsDir)) {
+                        for (const file of fs.readdirSync(migrationsDir)) {
+                          if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+                            migrationFiles.push(path.join(migrationsDir, file));
+                          }
+                        }
+                      }
+                    }
+                  }
+
+                  for (const absPath of migrationFiles) {
                     try {
                       if (dockerEnvFile) {
                         const containerPath = absPath.replace(projectRoot, '/var/www');

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -180,8 +180,12 @@ jobs:
               run: |
                 git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
                 git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+                git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
               env:
                 GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+            - name: Fix write permissions on project directory
+              run: sudo chmod -R a+w ${HOME}/build/project
 
             # Inject playwright.config.ts and playwright-global-setup.ts into the installed project.
             # testMatch discovers tests shipped by all installed Ibexa packages
@@ -310,7 +314,7 @@ jobs:
                   ],
                 });
                 EOF
-                npm install --no-save @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@github:ibexa/cohesivo-playwright#main
+                npm install --no-save @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
 
             - name: Install Playwright browsers
               run: |

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -336,6 +336,16 @@ jobs:
                 cd ${HOME}/build/project
                 echo "=== Playwright spec files found in vendor ==="
                 find vendor/ibexa -name "*.spec.ts" -path "*/playwright_ts/tests/*" 2>/dev/null || echo "None found"
+                echo "=== node_modules check ==="
+                for dir in vendor/ibexa/*/tests/playwright_ts; do
+                  if [ -d "$dir/node_modules/@ibexa/cohesivo-playwright" ]; then
+                    echo "✓ $dir has @ibexa/cohesivo-playwright"
+                  else
+                    echo "✗ $dir MISSING @ibexa/cohesivo-playwright"
+                  fi
+                done
+                echo "=== Listing tests (no run) ==="
+                NODE_PATH=/tmp/playwright-tools/node_modules /tmp/playwright-tools/node_modules/.bin/playwright test --list ${{ inputs.test-suite }} 2>&1 || true
                 echo "=== Running Playwright ==="
                 NODE_PATH=/tmp/playwright-tools/node_modules /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
               env:

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -191,8 +191,14 @@ jobs:
               run: |
                 for dir in ${HOME}/build/project/vendor/ibexa/*/tests/playwright_ts; do
                   if [ -f "$dir/package.json" ]; then
-                    echo "→ npm ci in $dir"
-                    cd "$dir" && npm ci
+                    cd "$dir"
+                    if [ -f "package-lock.json" ]; then
+                      echo "→ npm ci in $dir"
+                      npm ci
+                    else
+                      echo "→ npm install in $dir (no lock file)"
+                      npm install
+                    fi
                   fi
                 done
 
@@ -335,7 +341,7 @@ jobs:
                 echo "=== Playwright spec files found in vendor ==="
                 find vendor/ibexa -name "*.spec.ts" -path "*/playwright_ts/tests/*" 2>/dev/null || echo "None found"
                 echo "=== Running Playwright ==="
-                /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
+                NODE_PATH=/tmp/playwright-tools/node_modules /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080
                 DOCKER_COMPOSE_ENV_FILE: /home/runner/build/project/.env

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -141,12 +141,11 @@ jobs:
                  \"}}]}" >> $GITHUB_ENV
             - if: always() && github.event_name != 'pull_request' && job.status != 'success' && job.status != 'skipped'
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v1.23.0
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
+                  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  webhook-type: incoming-webhook
                   payload: ${{ env.SLACK_PAYLOAD }}
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     playwright-tests:
         needs: setup-jobs
@@ -353,9 +352,8 @@ jobs:
 
             - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v1.23.0
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
+                  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  webhook-type: incoming-webhook
                   payload: ${{ env.SLACK_PAYLOAD }}
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -43,7 +43,7 @@ on:
                 type: string
                 default: "main"
             cohesivo-version:
-                description: "Composer version constraint for ibexa/cohesivo-playwright. Empty = same as the project version (branch alias), so 4.6/5.0/6.0 branches get the matching library version."
+                description: "Composer version constraint for ibexa/cohesivo-playwright. Empty = match the project version (branch alias). Playwright is 5.0+ only — there is no 4.6 branch of the library, so 4.6 projects must not call this workflow."
                 required: false
                 type: string
                 default: ""
@@ -52,16 +52,6 @@ on:
                 required: false
                 type: string
                 default: "http://localhost:8080"
-            test-setup-phase-1:
-                description: "Behat suite to run before Playwright tests for data seeding - phase 1"
-                required: false
-                type: string
-                default: ""
-            test-setup-phase-2:
-                description: "Behat suite to run before Playwright tests for data seeding - phase 2"
-                required: false
-                type: string
-                default: ""
             job-count:
                 description: "Number of jobs that will run the tests in parallel (Playwright --shard)"
                 required: false
@@ -96,6 +86,10 @@ on:
                 required: false
 
 env:
+    # Symfony env the app boots in — the established platform test env (provided by ibexa/behat),
+    # same as the Behat pipeline and expected by the shared project-setup script. It configures
+    # the app, not Playwright (the tests just hit it over HTTP). There is no dedicated "playwright"
+    # env; dropping this would fall back to "dev", so it stays as-is.
     APP_ENV: behat
     APP_DEBUG: 1
     APP_SECRET: '2d4218d7b6c69a9f88da7b8986e64717b3c40948a7ba2b1ca309dc292472286d'
@@ -229,26 +223,16 @@ jobs:
                 cd ${HOME}/build/project
                 docker compose --env-file=.env exec -T --user www-data app sh -c "printf 'ibexa_integrated_help:\n    enabled: false\n' > config/packages/ibexa_integrated_help.yaml"
 
-            - if: inputs.test-setup-phase-1 != ''
-              name: Run first phase of tests setup
-              run: |
-                cd ${HOME}/build/project
-                docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
-                docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
-
-            - if: inputs.test-setup-phase-2 != ''
-              name: Run second phase of tests setup
-              run: |
-                cd ${HOME}/build/project
-                docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
-                docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
+            # Data seeding is done per-test through IbexaApiClient (REST) in the packages'
+            # beforeAll hooks — no Behat setup phase here, so this workflow has no Behat dependency.
 
             - name: Install ibexa/cohesivo-playwright
               run: |
                 cd ${HOME}/build/project
-                export COHESIVO_VERSION="${{ inputs.cohesivo-version }}"
+                # empty cohesivo-version → match the project version (branch alias), so a 5.0/6.0
+                # branch installs the matching library version. (No 4.6 branch of the library exists.)
                 if [ -z "$COHESIVO_VERSION" ]; then
-                  export COHESIVO_VERSION="${{ steps.project-version.outputs.version }}"
+                  COHESIVO_VERSION="$PROJECT_VERSION"
                 fi
                 echo "Installing ibexa/cohesivo-playwright:$COHESIVO_VERSION"
                 # TODO: drop the vcs repository once ibexa/cohesivo-playwright is published on updates.ibexa.co
@@ -258,6 +242,8 @@ jobs:
                   composer require --dev "ibexa/cohesivo-playwright:$COHESIVO_VERSION" --no-scripts --no-plugins'
               env:
                 GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+                COHESIVO_VERSION: ${{ inputs.cohesivo-version }}
+                PROJECT_VERSION: ${{ steps.project-version.outputs.version }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -298,34 +284,45 @@ jobs:
                 npx playwright install --with-deps chromium
 
             - name: Run Playwright tests
+              # inputs are passed via env (not interpolated into the script) to avoid shell injection
               run: |
                 cd ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
-                EXTRA_ARGS="${{ inputs.test-suite }}"
-                if [ "${{ needs.setup-jobs.outputs.job-count }}" -gt 1 ]; then
-                  EXTRA_ARGS="$EXTRA_ARGS --shard=$(( ${{ matrix.offset }} + 1 ))/${{ needs.setup-jobs.outputs.job-count }} --pass-with-no-tests"
+                EXTRA_ARGS="$TEST_SUITE"
+                if [ "$JOB_COUNT" -gt 1 ]; then
+                  EXTRA_ARGS="$EXTRA_ARGS --shard=$(( SHARD_OFFSET + 1 ))/$JOB_COUNT --pass-with-no-tests"
                 fi
-                if [ -n "${{ inputs.test-package }}" ]; then
-                  npm run test:package -- ${{ inputs.test-package }} $EXTRA_ARGS
+                if [ -n "$TEST_PACKAGE" ]; then
+                  npm run test:package -- "$TEST_PACKAGE" $EXTRA_ARGS
                 else
                   npm run test:all -- $EXTRA_ARGS
                 fi
               env:
+                TEST_SUITE: ${{ inputs.test-suite }}
+                TEST_PACKAGE: ${{ inputs.test-package }}
+                JOB_COUNT: ${{ needs.setup-jobs.outputs.job-count }}
+                SHARD_OFFSET: ${{ matrix.offset }}
                 APP_URL: ${{ inputs.app-url }}
                 APP_EDITION: ${{ inputs.project-edition }}
                 ADMIN_LOGIN: ${{ secrets.ADMIN_LOGIN || 'admin' }}
                 ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD || 'publish' }}
                 CI: true
 
+            - name: Report timestamp
+              if: always()
+              id: report-ts
+              run: echo "value=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+
             - name: Upload Playwright report
               if: always()
               uses: actions/upload-artifact@v4
               with:
-                  name: playwright-report-${{ inputs.project-edition }}-${{ matrix.offset }}
+                  # edition + shard make it unique within a run; UTC timestamp tells runs apart
+                  name: playwright-report-${{ inputs.project-edition }}-shard${{ matrix.offset }}-${{ steps.report-ts.outputs.value }}
+                  # `**` matches any depth, so one pair of globs covers both the package suites
+                  # (<pkg>/tests/playwright-tests/) and cohesivo's own tests (cohesivo-playwright/)
                   path: |
-                      /home/runner/build/project/vendor/ibexa/**/playwright-tests/playwright-report/
-                      /home/runner/build/project/vendor/ibexa/**/playwright-tests/test-results/
-                      /home/runner/build/project/vendor/ibexa/cohesivo-playwright/playwright-report/
-                      /home/runner/build/project/vendor/ibexa/cohesivo-playwright/test-results/
+                      /home/runner/build/project/vendor/ibexa/**/playwright-report/
+                      /home/runner/build/project/vendor/ibexa/**/test-results/
                   retention-days: 14
 
             - if: always() && github.event_name != 'pull_request'

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -7,8 +7,13 @@ on:
                 description: "Project edition to set up: oss, headless, experience, commerce"
                 required: true
                 type: string
+            test-package:
+                description: "Run tests of a single package (e.g. admin-ui). Empty = all packages with tests (edition mode)."
+                required: false
+                type: string
+                default: ''
             test-suite:
-                description: "Extra Playwright CLI args passed to test:all (e.g. --grep Trash)"
+                description: "Extra Playwright CLI args (e.g. --grep Trash)"
                 required: false
                 type: string
                 default: ''
@@ -37,6 +42,16 @@ on:
                 required: false
                 type: string
                 default: "main"
+            cohesivo-version:
+                description: "Composer version constraint for ibexa/cohesivo-playwright. Empty = same as the project version (branch alias), so 4.6/5.0/6.0 branches get the matching library version."
+                required: false
+                type: string
+                default: ""
+            app-url:
+                description: "URL under which the app is reachable from the runner host"
+                required: false
+                type: string
+                default: "http://localhost:8080"
             test-setup-phase-1:
                 description: "Behat suite to run before Playwright tests for data seeding - phase 1"
                 required: false
@@ -47,6 +62,11 @@ on:
                 required: false
                 type: string
                 default: ""
+            job-count:
+                description: "Number of jobs that will run the tests in parallel (Playwright --shard)"
+                required: false
+                type: number
+                default: 1
             send-success-notification:
                 description: "Send a Slack notification when tests pass"
                 required: false
@@ -83,10 +103,30 @@ env:
     COMPOSER_CACHE_DIR: ~/.composer/cache
 
 jobs:
-    setup-tests:
+    setup-jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 1
+        outputs:
+            matrix: ${{ steps.generate-matrix.outputs.matrix }}
+            job-count: ${{ steps.generate-matrix.outputs.job-count }}
         steps:
+            - name: Set job count for builds
+              run: echo "job_count=${{ inputs.job-count }}" >> $GITHUB_ENV
+            - name: Limit job-count to max 3 for PRs
+              if: github.event_name == 'pull_request'
+              run: |
+                if [[ "$job_count" -gt 3 ]] ; then
+                  job_count=3
+                fi
+                echo "job_count=$job_count" >> $GITHUB_ENV
+              env:
+                job_count: ${{ env.job_count }}
+            - name: Generate matrix
+              id: generate-matrix
+              run: |
+                matrix=$(jq -cn --argjson n "$job_count" '{offset: [range(0; $n)]}')
+                echo "matrix=$matrix" >> $GITHUB_OUTPUT
+                echo "job-count=$job_count" >> $GITHUB_OUTPUT
             - if: always() && github.event_name != 'pull_request'
               name: Create Slack message variables
               run: |
@@ -109,9 +149,12 @@ jobs:
                   SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     playwright-tests:
-        needs: setup-tests
+        needs: setup-jobs
         runs-on: ubuntu-latest
         timeout-minutes: ${{ inputs.timeout }}
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.setup-jobs.outputs.matrix) }}
 
         steps:
             - uses: actions/checkout@v4
@@ -122,9 +165,6 @@ jobs:
                 if [[ "$version" == "" ]] ; then
                     echo "Input project version not set, taking the value from composer.json"
                     version=$(cat composer.json | jq -r '.extra | ."branch-alias" | .[]')
-                fi
-                if [[ "$version" == "3.3.x-dev" ]] ; then
-                    version="^3.3.x-dev"
                 fi
                 echo "version=$version" >> $GITHUB_OUTPUT
               env:
@@ -146,11 +186,14 @@ jobs:
 
             - name: Generate token
               id: generate_token
+              if: env.AUTOMATION_CLIENT_ID != ''
               uses: actions/create-github-app-token@v2
               with:
                   app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                   private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
                   owner: ibexa
+              env:
+                  AUTOMATION_CLIENT_ID: ${{ secrets.AUTOMATION_CLIENT_ID }}
 
             - if: env.SATIS_NETWORK_KEY != ''
               name: Add composer keys for private packagist
@@ -192,14 +235,30 @@ jobs:
               run: |
                 cd ${HOME}/build/project
                 docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-1 }}"
-                docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
 
             - if: inputs.test-setup-phase-2 != ''
               name: Run second phase of tests setup
               run: |
                 cd ${HOME}/build/project
                 docker compose --env-file=.env exec -T --user www-data app sh -c "vendor/bin/ibexabehat ${{ inputs.test-setup-phase-2 }}"
-                docker compose --env-file=.env exec -T --user www-data app sh -c "composer run post-install-cmd"
+                docker compose --env-file=.env exec -T --user www-data app sh -c "NODE_OPTIONS='--max-old-space-size=3072' composer run post-install-cmd"
+
+            - name: Install ibexa/cohesivo-playwright
+              run: |
+                cd ${HOME}/build/project
+                COHESIVO_VERSION="${{ inputs.cohesivo-version }}"
+                if [ -z "$COHESIVO_VERSION" ]; then
+                  COHESIVO_VERSION="${{ steps.project-version.outputs.version }}"
+                fi
+                echo "Installing ibexa/cohesivo-playwright:$COHESIVO_VERSION"
+                # TODO: drop the vcs repository once ibexa/cohesivo-playwright is published on updates.ibexa.co
+                docker compose --env-file=.env exec -T --user www-data -e GITHUB_TOKEN -e COHESIVO_VERSION app sh -c '
+                  composer config repositories.cohesivo-playwright vcs https://github.com/ibexa/cohesivo-playwright &&
+                  if [ -n "$GITHUB_TOKEN" ]; then composer config github-oauth.github.com "$GITHUB_TOKEN"; fi &&
+                  composer require --dev "ibexa/cohesivo-playwright:$COHESIVO_VERSION" --no-scripts --no-plugins'
+              env:
+                GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -217,13 +276,6 @@ jobs:
 
             - name: Fix write permissions on project directory
               run: sudo chmod -R a+rwX ${HOME}/build/project
-
-            - name: Check cohesivo-playwright presence
-              run: |
-                echo "=== Checking vendor structure ==="
-                ls ${HOME}/build/project/vendor/ibexa/ | grep -E "cohesivo|admin" || echo "WARNING: expected packages not found"
-                echo "=== cohesivo-playwright contents ==="
-                ls ${HOME}/build/project/vendor/ibexa/cohesivo-playwright/ 2>/dev/null || echo "ERROR: cohesivo-playwright not found in vendor"
 
             - name: Install cohesivo-playwright dependencies and build
               run: |
@@ -249,9 +301,17 @@ jobs:
             - name: Run Playwright tests
               run: |
                 cd ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
-                npm run test:all -- ${{ inputs.test-suite }}
+                EXTRA_ARGS="${{ inputs.test-suite }}"
+                if [ "${{ needs.setup-jobs.outputs.job-count }}" -gt 1 ]; then
+                  EXTRA_ARGS="$EXTRA_ARGS --shard=$(( ${{ matrix.offset }} + 1 ))/${{ needs.setup-jobs.outputs.job-count }} --pass-with-no-tests"
+                fi
+                if [ -n "${{ inputs.test-package }}" ]; then
+                  npm run test:package -- ${{ inputs.test-package }} $EXTRA_ARGS
+                else
+                  npm run test:all -- $EXTRA_ARGS
+                fi
               env:
-                APP_URL: http://localhost:8080
+                APP_URL: ${{ inputs.app-url }}
                 APP_EDITION: ${{ inputs.project-edition }}
                 ADMIN_LOGIN: ${{ secrets.ADMIN_LOGIN || 'admin' }}
                 ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD || 'publish' }}
@@ -261,8 +321,41 @@ jobs:
               if: always()
               uses: actions/upload-artifact@v4
               with:
-                  name: playwright-report-${{ inputs.project-edition }}
+                  name: playwright-report-${{ inputs.project-edition }}-${{ matrix.offset }}
                   path: |
                       /home/runner/build/project/vendor/ibexa/**/playwright-tests/playwright-report/
                       /home/runner/build/project/vendor/ibexa/**/playwright-tests/test-results/
+                      /home/runner/build/project/vendor/ibexa/cohesivo-playwright/playwright-report/
+                      /home/runner/build/project/vendor/ibexa/cohesivo-playwright/test-results/
                   retention-days: 14
+
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message variables
+              run: |
+                echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
+                JOB_NUMBER=$(expr ${{ matrix.offset }} + 1)
+                echo "JOB_NUMBER=$JOB_NUMBER" >> $GITHUB_ENV
+
+            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
+              name: Create Slack message success variables
+              run: |
+                echo "RESULT_EMOJI=:white_check_mark:" >> $GITHUB_ENV
+
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message
+              run: >
+                 echo "SLACK_PAYLOAD=
+                 {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
+                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) | Playwright |
+                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details> |
+                 $JOB_NUMBER/${{ needs.setup-jobs.outputs.job-count }}
+                 \"}}]}" >> $GITHUB_ENV
+
+            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
+              name: Send notification about workflow result
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: ${{ env.SLACK_PAYLOAD }}
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -83,7 +83,33 @@ env:
     COMPOSER_CACHE_DIR: ~/.composer/cache
 
 jobs:
-    browser-tests:
+    setup-tests:
+        runs-on: ubuntu-latest
+        timeout-minutes: 1
+        steps:
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message variables
+              run: |
+                echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
+            - if: always() && github.event_name != 'pull_request'
+              name: Create Slack message
+              run: >
+                 echo "SLACK_PAYLOAD=
+                 {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
+                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
+                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
+                 \"}}]}" >> $GITHUB_ENV
+            - if: always() && github.event_name != 'pull_request' && job.status != 'success' && job.status != 'skipped'
+              name: Send notification about workflow result
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: ${{ env.SLACK_PAYLOAD }}
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    playwright-tests:
+        needs: setup-tests
         runs-on: ubuntu-latest
         timeout-minutes: ${{ inputs.timeout }}
 
@@ -192,6 +218,13 @@ jobs:
             - name: Fix write permissions on project directory
               run: sudo chmod -R a+rwX ${HOME}/build/project
 
+            - name: Check cohesivo-playwright presence
+              run: |
+                echo "=== Checking vendor structure ==="
+                ls ${HOME}/build/project/vendor/ibexa/ | grep -E "cohesivo|admin" || echo "WARNING: expected packages not found"
+                echo "=== cohesivo-playwright contents ==="
+                ls ${HOME}/build/project/vendor/ibexa/cohesivo-playwright/ 2>/dev/null || echo "ERROR: cohesivo-playwright not found in vendor"
+
             - name: Install cohesivo-playwright dependencies and build
               run: |
                 cd ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
@@ -233,31 +266,3 @@ jobs:
                       /home/runner/build/project/vendor/ibexa/**/playwright-tests/playwright-report/
                       /home/runner/build/project/vendor/ibexa/**/playwright-tests/test-results/
                   retention-days: 14
-
-            - if: always() && github.event_name != 'pull_request'
-              name: Create Slack message variables
-              run: |
-                echo "RESULT_EMOJI=:x:" >> $GITHUB_ENV
-
-            - if: always() && job.status == 'success' && github.event_name != 'pull_request'
-              name: Create Slack message success variables
-              run: |
-                echo "RESULT_EMOJI=:white_check_mark:" >> $GITHUB_ENV
-
-            - if: always() && github.event_name != 'pull_request'
-              name: Create Slack message
-              run: >
-                 echo "SLACK_PAYLOAD=
-                 {\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"
-                 $RESULT_EMOJI *$GITHUB_REPOSITORY*:*$GITHUB_REF_NAME* ($GITHUB_ACTOR) |
-                 <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Details>
-                 \"}}]}" >> $GITHUB_ENV
-
-            - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
-              name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: ${{ env.SLACK_PAYLOAD }}
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -8,9 +8,10 @@ on:
                 required: true
                 type: string
             test-suite:
-                description: "Playwright CLI args (e.g. --project=commerce)"
-                required: true
+                description: "Extra Playwright CLI args passed to test:all (e.g. --grep Trash)"
+                required: false
                 type: string
+                default: ''
             project-version:
                 description: "Project version (e.g. 6.0.x-dev). If empty, inferred from branch alias."
                 required: false
@@ -68,6 +69,10 @@ on:
             AUTOMATION_CLIENT_SECRET:
                 required: false
             EZROBOT_33:
+                required: false
+            ADMIN_LOGIN:
+                required: false
+            ADMIN_PASSWORD:
                 required: false
 
 env:
@@ -187,184 +192,34 @@ jobs:
             - name: Fix write permissions on project directory
               run: sudo chmod -R a+rwX ${HOME}/build/project
 
-            - name: Install npm dependencies in Playwright test directories
+            - name: Install cohesivo-playwright dependencies and build
               run: |
-                for dir in ${HOME}/build/project/vendor/ibexa/*/tests/playwright_ts; do
+                npm ci
+                npm run build
+              working-directory: ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
+
+            - name: Install per-package Playwright test dependencies
+              run: |
+                for dir in ${HOME}/build/project/vendor/ibexa/*/tests/playwright-tests; do
                   if [ -f "$dir/package.json" ]; then
                     cd "$dir"
-                    if [ -f "package-lock.json" ]; then
-                      echo "→ npm ci in $dir"
-                      npm ci
-                    else
-                      echo "→ npm install in $dir (no lock file)"
-                      npm install
-                    fi
+                    echo "→ npm ci in $dir"
+                    npm ci
                   fi
-                done
-
-            # Inject playwright.config.ts and playwright-global-setup.ts into the installed project.
-            # testMatch discovers tests shipped by all installed Ibexa packages
-            # under vendor/ibexa/*/tests/playwright_ts/tests/**/*.spec.ts
-            - name: Inject Playwright config into installed project
-              run: |
-                cd ${HOME}/build/project
-                cat > playwright-global-setup.ts << 'EOF'
-                import { chromium } from '@playwright/test';
-                import { execSync, execFileSync } from 'child_process';
-                import path from 'path';
-                import fs from 'fs';
-
-                export default async function globalSetup(): Promise<void> {
-                  const projectRoot = process.cwd();
-                  const dockerEnvFile = process.env.DOCKER_COMPOSE_ENV_FILE;
-
-                  // Discover migration YAML files from all installed Ibexa packages
-                  const migrationFiles: string[] = [];
-                  const vendorIbexa = path.join(projectRoot, 'vendor', 'ibexa');
-                  if (fs.existsSync(vendorIbexa)) {
-                    for (const pkg of fs.readdirSync(vendorIbexa)) {
-                      const migrationsDir = path.join(vendorIbexa, pkg, 'tests', 'playwright_ts', 'migrations');
-                      if (fs.existsSync(migrationsDir)) {
-                        for (const file of fs.readdirSync(migrationsDir)) {
-                          if (file.endsWith('.yaml') || file.endsWith('.yml')) {
-                            migrationFiles.push(path.join(migrationsDir, file));
-                          }
-                        }
-                      }
-                    }
-                  }
-
-                  for (const absPath of migrationFiles) {
-                    try {
-                      if (dockerEnvFile) {
-                        const containerPath = absPath.replace(projectRoot, '/var/www');
-                        execSync(
-                          `docker compose --env-file="${dockerEnvFile}" exec -T --user www-data app sh -c "php bin/console ibexa:migrations:import '${containerPath}' --no-interaction && php bin/console ibexa:migrations:migrate --no-interaction"`,
-                          { cwd: projectRoot, stdio: 'inherit' },
-                        );
-                      } else {
-                        execSync(
-                          `php bin/console ibexa:migrations:import "${absPath}" --no-interaction && php bin/console ibexa:migrations:migrate --no-interaction`,
-                          { cwd: projectRoot, stdio: 'inherit' },
-                        );
-                      }
-                    } catch {
-                      // migration already executed or non-fatal — continue
-                    }
-                  }
-
-                  // One-time browser login — saves session to playwright-auth.json
-                  const baseURL = process.env.APP_URL ?? 'http://localhost:8080';
-                  const adminUser = process.env.ADMIN_LOGIN ?? 'admin';
-                  const adminPassword = process.env.ADMIN_PASSWORD ?? 'publish';
-
-                  const browser = await chromium.launch({ headless: true });
-                  const context = await browser.newContext({ baseURL, locale: 'en-GB' });
-                  const page = await context.newPage();
-
-                  try {
-                    await page.goto('/admin/login');
-                    await page.waitForLoadState('domcontentloaded');
-                    await page.locator('#username').waitFor({ state: 'visible', timeout: 30_000 });
-                    await page.locator('#username').pressSequentially(adminUser);
-                    await page.keyboard.press('Tab');
-                    await page.locator('#password').pressSequentially(adminPassword);
-                    await page.keyboard.press('Tab');
-                    await page.locator('button[type="submit"].ibexa-login__btn--sign-in').waitFor({ state: 'visible', timeout: 10_000 });
-                    await page.locator('button[type="submit"].ibexa-login__btn--sign-in').click();
-                    await page.waitForURL('**/admin/**', { timeout: 60_000 });
-                    await page.waitForLoadState('networkidle');
-                    console.log('Login successful, current URL:', page.url());
-                    await context.storageState({ path: './playwright-auth.json' });
-                    console.log('Auth state saved to playwright-auth.json');
-                  } finally {
-                    await context.close();
-                    await browser.close();
-                  }
-                }
-                EOF
-
-                cat > playwright.config.ts << 'EOF'
-                import { defineConfig, devices } from '@playwright/test';
-
-                const baseURL = process.env.APP_URL ?? 'http://localhost:8080';
-
-                export default defineConfig({
-                  testDir: './vendor/ibexa',
-                  testMatch: /playwright_ts\/tests\/.*\.spec\.ts/,
-                  globalSetup: './playwright-global-setup.ts',
-                  fullyParallel: false,
-                  forbidOnly: !!process.env.CI,
-                  retries: process.env.CI ? 1 : 0,
-                  workers: process.env.CI ? 1 : undefined,
-                  timeout: 10_000,
-                  reporter: process.env.CI
-                    ? [['github'], ['html', { open: 'never', outputFolder: './playwright-report' }]]
-                    : [['html']],
-                  use: {
-                    baseURL,
-                    storageState: './playwright-auth.json',
-                    locale: 'en-GB',
-                    ignoreHTTPSErrors: true,
-                    trace: 'retain-on-failure',
-                    screenshot: 'only-on-failure',
-                    video: 'on-first-retry',
-                    viewport: { width: 1920, height: 1080 },
-                  },
-                  projects: [
-                    {
-                      name: 'oss',
-                      use: { ...devices['Desktop Chrome'] },
-                    },
-                    {
-                      name: 'headless',
-                      use: { ...devices['Desktop Chrome'] },
-                    },
-                    {
-                      name: 'experience',
-                      use: { ...devices['Desktop Chrome'] },
-                    },
-                    {
-                      name: 'commerce',
-                      use: { ...devices['Desktop Chrome'] },
-                    },
-                  ],
-                });
-                EOF
-                npm install --prefix /tmp/playwright-tools --legacy-peer-deps @playwright/test@^1.44.0 @ibexa/cohesivo-playwright@git+https://github.com/ibexa/cohesivo-playwright.git
-                mkdir -p node_modules/@playwright
-                ln -sf /tmp/playwright-tools/node_modules/@playwright/test node_modules/@playwright/test
-                ln -sf /tmp/playwright-tools/node_modules/playwright node_modules/playwright
-                for dir in vendor/ibexa/*/tests/playwright_ts/node_modules; do
-                  [ -d "$dir" ] && rm -rf "$dir/playwright" "$dir/@playwright" 2>/dev/null || true
                 done
 
             - name: Install Playwright browsers
-              run: |
-                /tmp/playwright-tools/node_modules/.bin/playwright install --with-deps chromium
+              run: npx playwright install --with-deps chromium
+              working-directory: ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
 
             - name: Run Playwright tests
-              run: |
-                cd ${HOME}/build/project
-                echo "=== Playwright spec files found in vendor ==="
-                find vendor/ibexa -name "*.spec.ts" -path "*/playwright_ts/tests/*" 2>/dev/null || echo "None found"
-                echo "=== node_modules check ==="
-                for dir in vendor/ibexa/*/tests/playwright_ts; do
-                  if [ -d "$dir/node_modules/@ibexa/cohesivo-playwright" ]; then
-                    echo "✓ $dir has @ibexa/cohesivo-playwright"
-                  else
-                    echo "✗ $dir MISSING @ibexa/cohesivo-playwright"
-                  fi
-                done
-                echo "=== Listing tests (no run) ==="
-                NODE_PATH=/tmp/playwright-tools/node_modules /tmp/playwright-tools/node_modules/.bin/playwright test --list ${{ inputs.test-suite }} 2>&1 || true
-                echo "=== Running Playwright ==="
-                NODE_PATH=/tmp/playwright-tools/node_modules /tmp/playwright-tools/node_modules/.bin/playwright test ${{ inputs.test-suite }}
+              run: npm run test:all -- ${{ inputs.test-suite }}
+              working-directory: ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
               env:
                 APP_URL: http://localhost:8080
-                DOCKER_COMPOSE_ENV_FILE: /home/runner/build/project/.env
-                ADMIN_LOGIN: admin
-                ADMIN_PASSWORD: publish
+                APP_EDITION: ${{ inputs.project-edition }}
+                ADMIN_LOGIN: ${{ secrets.ADMIN_LOGIN || 'admin' }}
+                ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD || 'publish' }}
                 CI: true
 
             - name: Upload Playwright report
@@ -372,7 +227,9 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: playwright-report-${{ inputs.project-edition }}
-                  path: /home/runner/build/project/playwright-report/
+                  path: |
+                      /home/runner/build/project/vendor/ibexa/**/playwright-tests/playwright-report/
+                      /home/runner/build/project/vendor/ibexa/**/playwright-tests/test-results/
                   retention-days: 14
 
             - if: always() && github.event_name != 'pull_request'

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -194,9 +194,9 @@ jobs:
 
             - name: Install cohesivo-playwright dependencies and build
               run: |
+                cd ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
                 npm ci
                 npm run build
-              working-directory: ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
 
             - name: Install per-package Playwright test dependencies
               run: |
@@ -209,12 +209,14 @@ jobs:
                 done
 
             - name: Install Playwright browsers
-              run: npx playwright install --with-deps chromium
-              working-directory: ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
+              run: |
+                cd ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
+                npx playwright install --with-deps chromium
 
             - name: Run Playwright tests
-              run: npm run test:all -- ${{ inputs.test-suite }}
-              working-directory: ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
+              run: |
+                cd ${HOME}/build/project/vendor/ibexa/cohesivo-playwright
+                npm run test:all -- ${{ inputs.test-suite }}
               env:
                 APP_URL: http://localhost:8080
                 APP_EDITION: ${{ inputs.project-edition }}

--- a/.github/workflows/playwright-browser-tests.yml
+++ b/.github/workflows/playwright-browser-tests.yml
@@ -247,9 +247,9 @@ jobs:
             - name: Install ibexa/cohesivo-playwright
               run: |
                 cd ${HOME}/build/project
-                COHESIVO_VERSION="${{ inputs.cohesivo-version }}"
+                export COHESIVO_VERSION="${{ inputs.cohesivo-version }}"
                 if [ -z "$COHESIVO_VERSION" ]; then
-                  COHESIVO_VERSION="${{ steps.project-version.outputs.version }}"
+                  export COHESIVO_VERSION="${{ steps.project-version.outputs.version }}"
                 fi
                 echo "Installing ibexa/cohesivo-playwright:$COHESIVO_VERSION"
                 # TODO: drop the vcs repository once ibexa/cohesivo-playwright is published on updates.ibexa.co


### PR DESCRIPTION
| :ticket: Issue | IBX-11740 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/commerce/pull/1833
- https://github.com/ibexa/admin-ui/pull/1947
- https://github.com/ibexa/cohesivo-playwright/pull/1


#### Description:
 Adds playwright-browser-tests.yml — a reusable workflow for running Playwright tests across Ibexa packages.
 
  - Reuses the existing app setup from browser-tests.yml (prepare_project_edition.sh, Behat data seeding phases, caching, Slack notifications)
  - Installs cohesivo-playwright from vendor, builds it, then runs npm run test:all
  - APP_EDITION is set from project-edition input — only tests tagged for the given edition are executed
  - No hardcoded credentials — uses secrets.ADMIN_LOGIN/ADMIN_PASSWORD with standard test defaults as fallback
  - Artifacts collected per edition from all playwright-tests/ directories in vendor


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
