### PR TITLE
IBX-11825: [Composer Audit Ignore] Added new advisories from Twig v3.26.0

### DIFF
--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -20,12 +20,7 @@ runs:
                 for advisory in \
                     PKSA-xwpn-zs9j-6wy5 \
                     PKSA-sf9j-1gs7-xzvx \
-                    PKSA-7h5p-prw9-w5nr \
-                    PKSA-fbvq-z33h-r2np \
-                    PKSA-g9zw-qxh8-pq8w \
-                    PKSA-yd6k-t2gh-1m43 \
-                    PKSA-1tmc-rt7x-12w6 \
-                    PKSA-xx6c-6d96-db2w
+                    PKSA-7h5p-prw9-w5nr
                 do
                     composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
                 done
@@ -57,7 +52,12 @@ runs:
                     PKSA-n7sg-8f52-pqtf \
                     PKSA-8kk8-h2xr-h5nx \
                     PKSA-2rbx-bjdx-4d4d \
-                    PKSA-fs5b-x5k4-1h39
+                    PKSA-fs5b-x5k4-1h39 \
+                    PKSA-fbvq-z33h-r2np \
+                    PKSA-g9zw-qxh8-pq8w \
+                    PKSA-yd6k-t2gh-1m43 \
+                    PKSA-1tmc-rt7x-12w6 \
+                    PKSA-xx6c-6d96-db2w
                 do
                     composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
                 done


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-11825 |
|----------------|-----------|

#### Related PRs:
- #96
- #97
- #101
- https://github.com/ibexa/admin-ui/pull/1926

#### Description:

Symfony has published new twig/twig advisories on May 27, for v3.26.0. I see we added them via #101, but these need to be added for PHP 8.0 too, as twig/twig v3.27.0 requires at least PHP 8.1

Ref.: https://packagist.org/packages/twig/twig/advisories?version=10147959

Verification: 
- :green_circle: https://github.com/ibexa/admin-ui/pull/1926