### PR TITLE
IBX-11778: [GHA] Updated deprecated versions of GitHub actions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -162,7 +162,7 @@ jobs:
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=http://varnish" >> $GITHUB_ENV
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Set up project version
               id: project-version

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -188,7 +188,7 @@ jobs:
               run: composer --version
 
             - name: Cache dependencies
-              uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
                   key: ${{ inputs.project-edition }}-${{ steps.project-version.outputs.version }}-${{ inputs.php-image }}-${{ github.sha }}

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -198,9 +198,9 @@ jobs:
 
             - name: Generate token
               id: generate_token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
-                  app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                  client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                   private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
                   owner: ${{ !contains(steps.project-version.outputs.version, '3.3') && 'ibexa' || 'ezsystems' }}
 

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -143,7 +143,7 @@ jobs:
                 \"}}]}" >> $GITHUB_ENV
             - if: always() && github.event_name != 'pull_request' && job.status != 'success' && job.status != 'skipped'
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
                 webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
                 webhook-type: incoming-webhook
@@ -161,7 +161,7 @@ jobs:
               name: "[Varnish] Set the URL the tests should access"
               run: echo "WEB_HOST=http://varnish" >> $GITHUB_ENV
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Set up project version
               id: project-version
@@ -178,7 +178,7 @@ jobs:
                 version: ${{ inputs.project-version }}
 
             - name: Setup PHP Action
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                   php-version: 8.3
                   coverage: none
@@ -188,7 +188,7 @@ jobs:
               run: composer --version
 
             - name: Cache dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
                   key: ${{ inputs.project-edition }}-${{ steps.project-version.outputs.version }}-${{ inputs.php-image }}-${{ github.sha }}
@@ -197,7 +197,7 @@ jobs:
 
             - name: Generate token
               id: generate_token
-              uses: actions/create-github-app-token@v3
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               with:
                   client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                   private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
@@ -367,7 +367,7 @@ jobs:
 
             - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
                   webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
                   webhook-type: incoming-webhook

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -143,7 +143,7 @@ jobs:
                 \"}}]}" >> $GITHUB_ENV
             - if: always() && github.event_name != 'pull_request' && job.status != 'success' && job.status != 'skipped'
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v3
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
               with:
                 webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
                 webhook-type: incoming-webhook
@@ -367,7 +367,7 @@ jobs:
 
             - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v3
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
               with:
                   webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
                   webhook-type: incoming-webhook

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -143,12 +143,11 @@ jobs:
                 \"}}]}" >> $GITHUB_ENV
             - if: always() && github.event_name != 'pull_request' && job.status != 'success' && job.status != 'skipped'
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v1.23.0
+              uses: slackapi/slack-github-action@v3
               with:
+                webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                webhook-type: incoming-webhook
                 payload: ${{ env.SLACK_PAYLOAD }}
-              env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     browser-tests:
         needs: setup-jobs
@@ -368,9 +367,8 @@ jobs:
 
             - if: always() && github.event_name != 'pull_request' && (job.status != 'success' || inputs.send-success-notification)
               name: Send notification about workflow result
-              uses: slackapi/slack-github-action@v1.23.0
+              uses: slackapi/slack-github-action@v3
               with:
+                  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  webhook-type: incoming-webhook
                   payload: ${{ env.SLACK_PAYLOAD }}
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-                  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 0
             token: ${{ secrets.robot-token }}

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -21,15 +21,18 @@ jobs:
           uses: rlespinasse/github-slug-action@v3.x
 
         - name: Get merge map
-          uses: octokit/request-action@v2.x
           id: map
           # Allow failures to be ignored.
           # We will consider output as empty
           continue-on-error: true
-          with:
-            owner: ibexa
-            repo: cross-merge-map
-            route: /repos/{owner}/{repo}/contents/${{ github.repository }}
+          shell: bash
+          run: |
+            response=$(gh api /repos/ibexa/cross-merge-map/contents/${{ github.repository }})
+            {
+              echo 'data<<EOF'
+              echo "$response"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
           env:
             GITHUB_TOKEN: ${{ secrets.robot-token }}
 

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           with:
             fetch-depth: 0
             token: ${{ secrets.robot-token }}
 
         - name: Inject slug/short variables
-          uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
+          uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5.6.0
 
         - name: Get merge map
           id: map

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -18,7 +18,7 @@ jobs:
             token: ${{ secrets.robot-token }}
 
         - name: Inject slug/short variables
-          uses: rlespinasse/github-slug-action@v5
+          uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
 
         - name: Get merge map
           id: map

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -27,7 +27,20 @@ jobs:
           continue-on-error: true
           shell: bash
           run: |
-            response=$(gh api /repos/ibexa/cross-merge-map/contents/${{ github.repository }})
+            map_repository="ibexa/cross-merge-map"
+            map_path="${{ github.repository }}"
+
+            echo "Fetching cross-merge map for ${map_path}"
+            echo "Map repository: ${map_repository}"
+
+            gh api "/repos/${map_repository}" >/dev/null
+
+            if ! response=$(gh api "/repos/${map_repository}/contents/${map_path}" 2>&1); then
+              echo "No cross-merge map found for ${map_path}. Skipping cross-merge."
+              echo "${response}"
+              exit 0
+            fi
+
             {
               echo 'data<<EOF'
               echo "$response"

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -18,7 +18,7 @@ jobs:
             token: ${{ secrets.robot-token }}
 
         - name: Inject slug/short variables
-          uses: rlespinasse/github-slug-action@v3.x
+          uses: rlespinasse/github-slug-action@v5
 
         - name: Get merge map
           id: map

--- a/.github/workflows/cross-merge.yml
+++ b/.github/workflows/cross-merge.yml
@@ -54,15 +54,31 @@ jobs:
           id: destinations
           if: ${{ steps.map.outputs.data }}
           run: |
+            source_branch="${{ github.ref_name }}"
+
             cat > input.json <<'EOF'
             ${{ steps.map.outputs.data }}
             EOF
+
             jq -r '.["content"]' input.json | base64 --decode | jq -c . > map.json
-            echo Looking for destination for branch ${{ env.GITHUB_REF_SLUG }}
-            branch=$(jq -r '.["${{ env.GITHUB_REF_SLUG }}"] | select (.!=null)' map.json)
-            echo Destination branch found. It is ${branch}
-            repo=$(jq -r '.DEST' map.json)
+            echo "Looking for destination for branch ${source_branch}"
+            echo "Configured source branches: $(jq -r 'keys - ["DEST"] | join(", ")' map.json)"
+
+            branch=$(jq -r --arg source_branch "$source_branch" '.[$source_branch] // empty' map.json)
+            if [ -z "$branch" ]; then
+              echo "No cross-merge destination configured for branch ${source_branch}. Skipping cross-merge."
+              exit 0
+            fi
+
+            repo=$(jq -r '.DEST // empty' map.json)
+            if [ -z "$repo" ]; then
+              echo "::error::Cross-merge map for ${{ github.repository }} does not define DEST"
+              exit 1
+            fi
+
             destination=temp_${{ env.GITHUB_REF_SLUG }}_to_$branch
+            echo "Destination branch found. It is ${branch}"
+            echo "Destination repository: ${repo}"
             echo "branch=$branch" >> $GITHUB_OUTPUT
             echo "repo=$repo" >> $GITHUB_OUTPUT
             echo "destination=$destination" >> $GITHUB_OUTPUT

--- a/.github/workflows/expand-team-reviewers.yml
+++ b/.github/workflows/expand-team-reviewers.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: generate_token
         with:
-          app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/expand-team-reviewers.yml
+++ b/.github/workflows/expand-team-reviewers.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate_token
         with:
           client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Authenticate as GitHub app
         id: generate_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
@@ -28,7 +28,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Trigger archive-maker via repository_dispatch
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
-          owner: ibexa
+          owner: ${{ github.repository_owner }}
 
       - name: Extract tag name
         id: tag

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: Authenticate as GitHub app
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
-          private_key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          owner: ibexa
 
       - name: Extract tag name
         id: tag

--- a/.github/workflows/pr-assign.yml
+++ b/.github/workflows/pr-assign.yml
@@ -19,16 +19,19 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0 as of 25.03.2026
-        name: Get list of assignees
+      - name: Get list of assignees
         id: assignees
         # Allow failures to be ignored.
         # We will consider output as empty
         continue-on-error: true
-        with:
-          owner: ibexa
-          repo: pr-assignees
-          route: /repos/{owner}/{repo}/contents/${{ github.repository }}/maintainers
+        shell: bash
+        run: |
+          response=$(gh api /repos/ibexa/pr-assignees/contents/${{ github.repository }}/maintainers)
+          {
+            echo 'data<<EOF'
+            echo "$response"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.robot-token }}
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,24 +7,34 @@ jobs:
     name: Pull Request base branch verification
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
-        name: Get PR's composer.json
+      - name: Get PR's composer.json
         id: pr
-        with:
-          branch: "!!str ${{ github.event.pull_request.head.ref }}"
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          route: /repos/{repository}/contents/composer.json?ref={branch}
+        shell: bash
+        run: |
+          response=$(gh api --method GET "/repos/${REPOSITORY}/contents/composer.json" -f ref="$BRANCH")
+          {
+            echo 'data<<EOF'
+            echo "$response"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ github.token }}  
-      - uses: octokit/request-action@v2.x
-        name: Get base's composer.json
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Get base's composer.json
         id: base
-        with:
-          branch: "!!str ${{ github.event.pull_request.base.ref }}"
-          repository: ${{ github.event.pull_request.base.repo.full_name }}
-          route: /repos/{repository}/contents/composer.json?ref={branch}
+        shell: bash
+        run: |
+          response=$(gh api --method GET "/repos/${REPOSITORY}/contents/composer.json" -f ref="$BRANCH")
+          {
+            echo 'data<<EOF'
+            echo "$response"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ github.token }}  
+          BRANCH: ${{ github.event.pull_request.base.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
       - name: Verify base branch
         run: |
           PR_BRANCH_ALIAS=$(echo $PR_DATA | jq -r '.["content"]' | base64 --decode | jq -r '.["extra"]["branch-alias"] | flatten | .[0]')

--- a/.github/workflows/pr-label-reactor.yml
+++ b/.github/workflows/pr-label-reactor.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: slack-send
       if: ${{ env.channel-id }}
-      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         method: chat.postMessage
         token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/pr-label-reactor.yml
+++ b/.github/workflows/pr-label-reactor.yml
@@ -19,12 +19,13 @@ jobs:
 
     - name: slack-send
       if: ${{ env.channel-id }}
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      uses: slackapi/slack-github-action@v1.26.0
+      uses: slackapi/slack-github-action@v3
       with:
-        channel-id: ${{ env.channel-id }}
-        slack-message: "${{ github.event.pull_request._links.html.href }} from @${{ github.event.pull_request.user.login }} is now ${{ github.event.label.name }}"
+        method: chat.postMessage
+        token: ${{ secrets.SLACK_BOT_TOKEN }}
+        payload: |
+          channel: ${{ env.channel-id }}
+          text: "${{ github.event.pull_request._links.html.href }} from @${{ github.event.pull_request.user.login }} is now ${{ github.event.label.name }}"
 
   unlabeler:
     if: github.event.action == 'unlabeled'

--- a/.github/workflows/pr-label-reactor.yml
+++ b/.github/workflows/pr-label-reactor.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: slack-send
       if: ${{ env.channel-id }}
-      uses: slackapi/slack-github-action@v3
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
       with:
         method: chat.postMessage
         token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/raptor-pr-checks.yml
+++ b/.github/workflows/raptor-pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check if branch is up to date with base branch

--- a/.github/workflows/raptor-pr-checks.yml
+++ b/.github/workflows/raptor-pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Check if branch is up to date with base branch

--- a/.github/workflows/reactor-linters.yml
+++ b/.github/workflows/reactor-linters.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: json-yaml-validate
         uses: GrantBirki/json-yaml-validate@v2.7.1
         with:

--- a/.github/workflows/reactor-linters.yml
+++ b/.github/workflows/reactor-linters.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@v2.7.1
+        uses: GrantBirki/json-yaml-validate@3ff75979f3b21171f2e8a44705f0ff4bed30bbc0 # v5.0.0
         with:
           use_dot_match: "false"

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - uses: ibexa/gh-workflows/actions/composer-install@main
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set Environment
         run: |
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # load current composer.lock
       - id: currentLock
@@ -48,7 +48,7 @@ jobs:
           prevFullTag: ${{ steps.prevfull.outputs.tag }}
 
       # checkout previous tag
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.prevrelease.outputs.previousTag }}
 
@@ -106,7 +106,7 @@ jobs:
           currentTag: ${{ env.BUILD_TAG }}
 
       - name: Checkout Generator
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ibexa/changelog-generator-action
           ref: v2
@@ -153,7 +153,7 @@ jobs:
           path: generator_output
 
       - name: Check out wiki
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: '${{ github.repository }}.wiki'
           path: 'wiki'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set Environment
         run: |
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # load current composer.lock
       - id: currentLock
@@ -42,13 +42,13 @@ jobs:
 
       - name: Get previous release tag based on type
         id: prevrelease
-        uses: ibexa/version-logic-action@master
+        uses: ibexa/version-logic-action@e15eb95abe03085d43bb35030a7fc9bb625ae7b7 # v1.3.2
         with:
           currentTag: ${{ env.BUILD_TAG }}
           prevFullTag: ${{ steps.prevfull.outputs.tag }}
 
       # checkout previous tag
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.prevrelease.outputs.previousTag }}
 
@@ -94,25 +94,25 @@ jobs:
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
           owner: ibexa
       - name: Get previous release tag based on type
         id: prevrelease
-        uses: ibexa/version-logic-action@master
+        uses: ibexa/version-logic-action@e15eb95abe03085d43bb35030a7fc9bb625ae7b7 # v1.3.2
         with:
           currentTag: ${{ env.BUILD_TAG }}
 
       - name: Checkout Generator
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ibexa/changelog-generator-action
           ref: v2
 
       - name: Setup Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 
@@ -147,13 +147,13 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Archive markdown
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: changelogs
           path: generator_output
 
       - name: Check out wiki
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: '${{ github.repository }}.wiki'
           path: 'wiki'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,10 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: zendesk/action-gh-release@v2
-        with:
-          tag_name: ${{ env.BUILD_TAG }}
-          body: |
-            The full changelog for this release is available at: https://github.com/${{ github.repository }}/wiki/Changelog-${{ env.BUILD_TAG }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > release_notes.md <<'EOF'
+          The full changelog for this release is available at: https://github.com/${{ github.repository }}/wiki/Changelog-${{ env.BUILD_TAG }}
+          EOF
+          gh release create "$BUILD_TAG" --title "$BUILD_TAG" --notes-file release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
-          owner: ibexa
+          owner: ${{ github.repository_owner }}
       - name: Get previous release tag based on type
         id: prevrelease
         uses: ibexa/version-logic-action@e15eb95abe03085d43bb35030a7fc9bb625ae7b7 # v1.3.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,11 @@ jobs:
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
-          private_key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          owner: ibexa
       - name: Get previous release tag based on type
         id: prevrelease
         uses: ibexa/version-logic-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
         id: create_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           cat > release_notes.md <<'EOF'
           The full changelog for this release is available at: https://github.com/${{ github.repository }}/wiki/Changelog-${{ env.BUILD_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get previous last full release
         id: prevfull
         run: |
-          OUT=$(hub api /repos/${{ github.repository }}/releases | jq -r '[.[] | select(.tag_name | test("^(?!.*alpha|.*beta|.*rc).*$")) | .tag_name] | sort_by(.) | last')
+          OUT=$(gh api --paginate "/repos/${{ github.repository }}/releases" | jq -r -s 'flatten | [.[] | select(.tag_name | test("^(?!.*alpha|.*beta|.*rc).*$")) | .tag_name] | sort_by(.) | last')
           echo "tag=$( echo "$OUT" )" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - name: Set Environment
         run: |
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV

--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -37,10 +37,10 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: zendesk/action-gh-release@v2
-        with:
-          tag_name: ${{ env.BUILD_TAG }}
-          body: |
-            ${{ steps.changelog.outputs.changelog }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > release_notes.md <<'EOF'
+          ${{ steps.changelog.outputs.changelog }}
+          EOF
+          gh release create "$BUILD_TAG" --title "$BUILD_TAG" --notes-file release_notes.md

--- a/.github/workflows/release_bundle.yml
+++ b/.github/workflows/release_bundle.yml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set Environment
         run: |
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Get previous release tag based on type
         id: prevrelease
-        uses: ibexa/version-logic-action@master
+        uses: ibexa/version-logic-action@e15eb95abe03085d43bb35030a7fc9bb625ae7b7 # v1.3.2
         with:
           currentTag: ${{ env.BUILD_TAG }}
 
       - name: Generate changelog
         id: changelog
-        uses: ibexa/changelog-generator-action@v2
+        uses: ibexa/changelog-generator-action@v2 # referencing `v2` branch, not tag. Do not change unless new tag exists
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           jira_token: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -11,7 +11,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.robot-token }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ steps.destinations.outputs.destination }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.DEST_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -60,10 +60,17 @@ jobs:
           ${{ steps.map.outputs.data }}
           EOF
           jq -r '.["content"]' input.json | base64 --decode | jq -c . > map.json
-          branch=${{ env.GITHUB_REF_SLUG }}
-          echo Looking for destination for branch $branch
-          destination=$(jq -r '.["${{ env.GITHUB_REF_SLUG }}"] | select (.!=null)' map.json)
-          echo Destination branch found. It is ${destination} branch
+          branch="${{ env.GITHUB_REF_SLUG }}"
+          echo "Looking for destination for branch ${branch}"
+          echo "Configured source branches: $(jq -r 'keys | join(", ")' map.json)"
+
+          destination=$(jq -r --arg branch "$branch" '.[$branch] // empty' map.json)
+          if [ -z "$destination" ]; then
+            echo "No upmerge destination configured for branch ${branch}. Skipping upmerge."
+            exit 0
+          fi
+
+          echo "Destination branch found. It is ${destination} branch"
           echo "SOURCE_BRANCH=$branch" >> $GITHUB_ENV
           echo "DEST_BRANCH=$destination" >> $GITHUB_ENV
           echo "destination=$destination" >> $GITHUB_OUTPUT

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate_token
         with:
           client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
           owner: ${{ github.repository_owner }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
@@ -33,7 +33,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com>"
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5.6.0
 
       - name: Get merge map
         id: map
@@ -70,7 +70,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ steps.destinations.outputs.destination }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.DEST_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com>"
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v5
 
       - name: Get merge map
         id: map

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -3,18 +3,29 @@ name: Upmerge branch (callee)
 on:
   workflow_call:
     secrets:
-      robot-token:
-        description: 'A PAT token used by the app/robot'
+      AUTOMATION_CLIENT_ID:
+        description: 'GitHub App ID'
+        required: true
+      AUTOMATION_CLIENT_SECRET:
+        description: 'GitHub App private key'
         required: true
 
 jobs:
   merge:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v3
+        id: generate_token
+        with:
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.robot-token }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Set environment
         run: |
@@ -38,7 +49,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.robot-token }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       # Parse json and find destination branch and repository
       - name: Set variables
@@ -63,8 +74,7 @@ jobs:
         with:
           ref: ${{ env.DEST_BRANCH }}
           fetch-depth: 0
-          persist-credentials: false
-          token: ${{ secrets.robot-token }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Perform Upmerge of ${{ env.SOURCE_BRANCH }} to ${{ env.DEST_BRANCH }}
         if: ${{ steps.destinations.outputs.destination }}
@@ -73,7 +83,5 @@ jobs:
 
       - name: Push changes
         if: ${{ steps.destinations.outputs.destination }}
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.robot-token }}
-          branch: ${{ env.DEST_BRANCH }}
+        run: |
+          git push origin "HEAD:${DEST_BRANCH}"

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -25,15 +25,18 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Get merge map
-        uses: octokit/request-action@v2.x
         id: map
         # Allow failures to be ignored.
         # We will consider output as empty
         continue-on-error: true
-        with:
-          owner: ibexa
-          repo: upmerge-map
-          route: /repos/{owner}/{repo}/contents/${{ github.repository }}
+        shell: bash
+        run: |
+          response=$(gh api /repos/ibexa/upmerge-map/contents/${{ github.repository }})
+          {
+            echo 'data<<EOF'
+            echo "$response"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.robot-token }}
 

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com>"
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v5
+        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5
 
       - name: Get merge map
         id: map

--- a/actions/composer-install/action.yml
+++ b/actions/composer-install/action.yml
@@ -37,7 +37,7 @@ runs:
     using: "composite"
     steps:
         -   if: ${{ inputs.gh-client-id != '' && inputs.gh-client-secret != '' }}
-            uses: actions/create-github-app-token@v3
+            uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
             id: generate_token
             with:
                 client-id: ${{ inputs.gh-client-id }}
@@ -45,7 +45,7 @@ runs:
                 owner: ${{ github.repository_owner }}
 
         -   name: Setup PHP Action
-            uses: shivammathur/setup-php@v2
+            uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
             id: setup_php
             with:
                 php-version: ${{ matrix.php }}
@@ -84,7 +84,7 @@ runs:
                 php-version: ${{ steps.setup_php.outputs.php-version }}
                 ci-scripts-ref: ${{ inputs.ci-scripts-ref }}
 
-        -   uses: ramsey/composer-install@v4
+        -   uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
             with:
                 dependency-versions: highest
                 composer-options: ${{ inputs.composer-options }}

--- a/actions/composer-install/action.yml
+++ b/actions/composer-install/action.yml
@@ -37,10 +37,10 @@ runs:
     using: "composite"
     steps:
         -   if: ${{ inputs.gh-client-id != '' && inputs.gh-client-secret != '' }}
-            uses: actions/create-github-app-token@v2
+            uses: actions/create-github-app-token@v3
             id: generate_token
             with:
-                app-id: ${{ inputs.gh-client-id }}
+                client-id: ${{ inputs.gh-client-id }}
                 private-key: ${{ inputs.gh-client-secret }}
                 owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commits before merging
 
| :ticket: Issue | IBX-11778 |
|----------------|-----------|

#### Description:

This PR updates GitHub workflows and the Composer install composite action that depended on actions using deprecated Node.js runtimes.

The changes include:
- upgrading `actions/checkout` to v7 in affected workflows;
- upgrading `actions/create-github-app-token` to v3 and switching from the deprecated `app-id` input to `client-id`;
- upgrading `slackapi/slack-github-action` to v3 and updating both incoming webhook and Slack API call inputs;
- pinning non-ibexa actions to their respective version tag commits SHAs [^1];
- replacing `octokit/request-action` usages with equivalent `gh api` calls while preserving the `data` output consumed by later steps;
- replacing deprecated release and push helper actions with direct `gh release create` and `git push` commands;
- updating the upmerge workflow to generate and reuse a GitHub App token instead of requiring the `robot-token` secret.

#### For QA:

No manual QA is required. Workflow validation should focus on regression coverage for the touched workflows, especially Browser Tests and workflows that now use `gh api`, `gh release create`, or generated GitHub App tokens.

Test status:

- [x] :green_circle: Browser Tests stack with dependencies.json handling [Browser Tests run 28132632096](https://github.com/ibexa/core/actions/runs/28132632096) via ibexa/core#766
- [x] :green_circle: `actions/checkout` [Backend CI run 28132631469](https://github.com/ibexa/core/actions/runs/28132631469) via ibexa/core#766
- [x] :green_circle: `actions/create-github-app-token` [Backend CI run 28132631469](https://github.com/ibexa/core/actions/runs/28132631469) via ibexa/core#766
- [x] :green_circle: `slackapi/slack-github-action` [Browser Tests run 28132632096](https://github.com/ibexa/core/actions/runs/28132632096) via ibexa/core#766
- [x] :green_circle: Cross-merge workflow [run 28171377660](https://github.com/ezsystems/ezplatform-kernel/actions/runs/28171377660) via https://github.com/ezsystems/ezplatform-kernel/pull/414
- [x] :green_circle: Assign Pull Request to Maintainers workflow [run 28175813092](https://github.com/ezsystems/ezpublish-kernel/actions/runs/28175813092) via ezsystems/ezpublish-kernel#3157
- [x] :green_circle: PR base branch check workflow [PR check run 28172921268](https://github.com/ibexa/core/actions/runs/28172921268)  via ibexa/core#766
- [x] :green_circle: Rector workflow [Rector run 28200112994](https://github.com/ibexa/core/actions/runs/28200112994) via ibexa/core#769

- [x] :green_circle: `.github/workflows/upmerge.yml` [Merge-up run 28246294979](https://github.com/ibexa/gha-testing/actions/runs/28246294979) via https://github.com/ibexa/gha-testing/commit/e6c51daa62cb988e288e2664f118d7082f2acb5c
- [x] :green_circle:  `.github/workflows/release.yml` [Create release run 28800435938](https://github.com/ibexa/gha-testing/actions/runs/28800435938) producing [ibexa/gha-testing@v0.2.2](https://github.com/ibexa/gha-testing/releases/tag/v0.2.2)
- [x] :green_circle: Create Changelog for package (`release_bundle.yml`) [Changelog generator run 28248909431](https://github.com/ibexa/gha-testing/actions/runs/28248909431) via https://github.com/ibexa/gha-testing/releases/tag/v0.1.3
- [x] :green_circle:  `.github/workflows/post_release.yaml` tested via a test harness on ibexa/gha-testing:
  - [Post release caller run 28804879210](https://github.com/ibexa/gha-testing/actions/runs/28804879210) with the dispatch temporarily redirected to gha-testing; the payload was received and verified by [Dispatch echo run 28804896394](https://github.com/ibexa/gha-testing/actions/runs/28804896394)
  - [Post release caller run 28805074228](https://github.com/ibexa/gha-testing/actions/runs/28805074228) dispatching an inert event type to the real `ibexa/archive-maker`, proving the app token has access there without triggering any workflow


#### Documentation:

No documentation required.

[^1]: According to SonarQube security analysis, pinning GHA action version to specific commit is more secure than using a tag or a branch (as both can be force-pushed by a supply-chain attack). These are generic reusable workflows, so they don't produce too much maintenance. However it doesn't provide any value for `ibexa/*` actions and workflows.


