### PR TITLE
IBX-12028: [Composer Audit Ignore] Refactored action to use common source of truth

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -232,6 +232,7 @@ jobs:
                 LAMBDATEST_USERNAME: "${{ secrets.LAMBDATEST_USERNAME }}"
                 LAMBDATEST_ACCESS_KEY: "${{ secrets.LAMBDATEST_ACCESS_KEY }}"
                 INSTALL_CONNECTOR_QUABLE: ${{ inputs.install-connector-quable }}
+                CI_SCRIPTS_REF: ${{ inputs.ci-scripts-branch }}
 
             - if: startsWith(steps.project-version.outputs.version, 'v')
               name: Set up whole project using a stable release
@@ -246,6 +247,7 @@ jobs:
                 LAMBDATEST_USERNAME: "${{ secrets.LAMBDATEST_USERNAME }}"
                 LAMBDATEST_ACCESS_KEY: "${{ secrets.LAMBDATEST_ACCESS_KEY }}"
                 INSTALL_CONNECTOR_QUABLE: ${{ inputs.install-connector-quable }}
+                CI_SCRIPTS_REF: ${{ inputs.ci-scripts-branch }}
 
             - if: inputs.use-compatibility-layer
               name: Set up compatibility-layer

--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -7,6 +7,10 @@ inputs:
     php-version:
         description: 'PHP version'
         required: true
+    ci-scripts-ref:
+        description: "The branch/ref from ibexa/ci-scripts repository that should be used"
+        required: false
+        default: "main"
 
 runs:
     using: "composite"
@@ -16,6 +20,6 @@ runs:
             run: |
                 script=$(mktemp)
                 curl -fsSL \
-                    https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/_common/configure_composer_audit_ignores.sh \
+                    "https://raw.githubusercontent.com/ibexa/ci-scripts/${{ inputs.ci-scripts-ref }}/bin/_common/configure_composer_audit_ignores.sh" \
                     --output "$script"
                 bash "$script" "${{ inputs.php-version }}"

--- a/actions/composer-audit-ignore/action.yml
+++ b/actions/composer-audit-ignore/action.yml
@@ -11,53 +11,11 @@ inputs:
 runs:
     using: "composite"
     steps:
-        -   if: startsWith(inputs.php-version, '7.4')
-            name: Configure PHP 7.4-only advisory ignore list
+        -   name: Configure advisory ignore list
             shell: bash
             run: |
-                reason="The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8.1+"
-
-                for advisory in \
-                    PKSA-xwpn-zs9j-6wy5 \
-                    PKSA-sf9j-1gs7-xzvx \
-                    PKSA-7h5p-prw9-w5nr
-                do
-                    composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
-                done
-
-        -   if: startsWith(inputs.php-version, '7.4') || startsWith(inputs.php-version, '8.0')
-            name: Configure shared advisory ignore list for PHP 7.4 and 8.0
-            env:
-                PHP_VERSION: ${{ inputs.php-version }}
-            shell: bash
-            run: |
-                reason="The affected version of 3rd party component is installed on PHP ${PHP_VERSION%.*}. There's no alternative supporting PHP ${PHP_VERSION%.*}. Consider upgrading to PHP 8.1+"
-
-                for advisory in \
-                    PKSA-5k7f-wvjj-jrgw \
-                    PKSA-sjvz-tbbr-vwth \
-                    PKSA-h8hf-ytnd-5t9q \
-                    PKSA-wwb1-81rc-pd65 \
-                    PKSA-hgmw-wn4d-hpcy \
-                    PKSA-kvv6-36cr-fkzb \
-                    PKSA-n14z-jjjg-g8vd \
-                    PKSA-3mcc-k66d-pydb \
-                    PKSA-gw7n-z4yx-7xjt \
-                    PKSA-dpx1-78wg-1kqs \
-                    PKSA-21g2-dzjv-sky5 \
-                    PKSA-v3kg-5xkr-pykw \
-                    PKSA-yhcn-xrg3-68b1 \
-                    PKSA-2wrf-1xmk-1pky \
-                    PKSA-6319-ffpf-gx66 \
-                    PKSA-n7sg-8f52-pqtf \
-                    PKSA-8kk8-h2xr-h5nx \
-                    PKSA-2rbx-bjdx-4d4d \
-                    PKSA-fs5b-x5k4-1h39 \
-                    PKSA-fbvq-z33h-r2np \
-                    PKSA-g9zw-qxh8-pq8w \
-                    PKSA-yd6k-t2gh-1m43 \
-                    PKSA-1tmc-rt7x-12w6 \
-                    PKSA-xx6c-6d96-db2w
-                do
-                    composer config audit.ignore --json --merge "{\"$advisory\":\"$reason\"}"
-                done
+                script=$(mktemp)
+                curl -fsSL \
+                    https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/_common/configure_composer_audit_ignores.sh \
+                    --output "$script"
+                bash "$script" "${{ inputs.php-version }}"

--- a/actions/composer-install/action.yml
+++ b/actions/composer-install/action.yml
@@ -28,6 +28,10 @@ inputs:
     composer-options:
         description: 'Additional options to pass to composer'
         required: false
+    ci-scripts-ref:
+        description: "The branch/ref from ibexa/ci-scripts repository that should be used"
+        required: false
+        default: "main"
 
 runs:
     using: "composite"
@@ -78,6 +82,7 @@ runs:
             uses: ibexa/gh-workflows/actions/composer-audit-ignore@main
             with:
                 php-version: ${{ steps.setup_php.outputs.php-version }}
+                ci-scripts-ref: ${{ inputs.ci-scripts-ref }}
 
         -   uses: ramsey/composer-install@v4
             with:


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging
 
| :ticket: Issue | IBX-12028 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/ci-scripts/pull/141
- #97
- https://github.com/ibexa/docker/pull/63


#### Description:

Refactored the `ibexa/gh-workflows/actions/composer-audit-ignore/action.yml` GHA to rely on common/shared source of truth in ci-scripts rather than update hardcoded list everywhere every time Symfony decides to publish yet another advisory.

The new source of truth includes newly published [PKSA-8zx5-v2nz-58pb](https://packagist.org/security-advisories/PKSA-8zx5-v2nz-58pb) (https://github.com/advisories/GHSA-529h-vh3j-85hq).

Additionally, to better streamline testing of any changes to scripts fetched from `ci-scripts` via `curl`, `CI_SCRIPTS_REF` environment variable and a corresponding `ci-scripts-ref` GHA action input was added.


#### For QA:
No QA required.

Tested via:
- ibexa/discounts#337 together with IBX-11778 changes, :green_circle: [Backend CI build 28668970553/job/85027737107](https://github.com/ibexa/discounts/actions/runs/28668970553/job/85027737107?pr=337).
- ibexa/commerce#1865 :green_circle: [Browser tests run 28669302869](https://github.com/ibexa/commerce/actions/runs/28669302869)

#### Documentation:

No documentation required.