### PR TITLE
IBX-11778: Added composite actions for metapackage Create Tag workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# actionlint validates runner labels against a built-in list that lags behind
+# the images GitHub actually offers. Declare the labels we standardize on but
+# that actionlint does not know yet, so they are not reported as unknown.
+self-hosted-runner:
+    labels:
+        - ubuntu-26.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     bats:
         name: Bats tests
-        runs-on: ubuntu-latest
+        runs-on: "ubuntu-26.04"
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -21,7 +21,7 @@ jobs:
 
     shellcheck:
         name: Shellcheck
-        runs-on: ubuntu-latest
+        runs-on: "ubuntu-26.04"
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -33,14 +33,14 @@ jobs:
 
     actionlint:
         name: Actionlint
-        runs-on: ubuntu-latest
+        runs-on: "ubuntu-26.04"
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Install actionlint
               env:
-                  VERSION: 1.7.7
-                  SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+                  VERSION: 1.7.12
+                  SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
               run: |
                   curl -sfL --proto '=https' -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
                   echo "${SHA256}  actionlint.tar.gz" | sha256sum -c -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,18 @@ jobs:
             - name: Run bats tests
               run: bats tests/
 
+    shellcheck:
+        name: Shellcheck
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Install shellcheck
+              run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+            - name: Run shellcheck on action scripts
+              run: shellcheck actions/*/*.bash
+
     actionlint:
         name: Actionlint
         runs-on: ubuntu-latest
@@ -30,10 +42,12 @@ jobs:
                   VERSION: 1.7.7
                   SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
               run: |
-                  curl -sfL -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+                  curl -sfL --proto '=https' -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
                   echo "${SHA256}  actionlint.tar.gz" | sha256sum -c -
                   tar xzf actionlint.tar.gz actionlint
                   rm actionlint.tar.gz
 
             - name: Run actionlint
-              run: ./actionlint -color
+              # The shellcheck integration is disabled until the pre-existing
+              # workflows are made shellcheck-clean.
+              run: ./actionlint -color -shellcheck=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+    pull_request: ~
+
+jobs:
+    bats:
+        name: Bats tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Install bats
+              run: sudo apt-get update && sudo apt-get install -y bats
+
+            - name: Run bats tests
+              run: bats tests/
+
+    actionlint:
+        name: Actionlint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Install actionlint
+              env:
+                  VERSION: 1.7.7
+                  SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+              run: |
+                  curl -sfL -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+                  echo "${SHA256}  actionlint.tar.gz" | sha256sum -c -
+                  tar xzf actionlint.tar.gz actionlint
+                  rm actionlint.tar.gz
+
+            - name: Run actionlint
+              run: ./actionlint -color

--- a/actions/check-composer-package/action.yml
+++ b/actions/check-composer-package/action.yml
@@ -1,0 +1,52 @@
+name: "Check that a package version is available in a Composer repository"
+author: 'Ibexa AS'
+description: >-
+    Checks that a package version is available in a Composer repository
+    (Packagist by default, or a Satis instance via repository-url + auth).
+    With retry enabled, re-checks on the retry-schedule delays before
+    failing — for packages that are being published while the caller runs.
+
+inputs:
+    package:
+        description: 'Composer package name, e.g. ibexa/experience'
+        required: true
+    version:
+        description: 'Version to look for, as published (e.g. v4.6.30)'
+        required: true
+    repository-url:
+        description: 'Composer repository URL'
+        required: false
+        default: 'https://repo.packagist.org'
+    auth-key:
+        description: 'HTTP basic auth user (e.g. Satis network key)'
+        required: false
+    auth-token:
+        description: 'HTTP basic auth password (e.g. Satis network token)'
+        required: false
+    retry:
+        description: >-
+            Whether to re-check on the retry-schedule delays before failing.
+            Enable for packages being published while the caller runs; leave
+            disabled when absence means a mistake that should fail fast.
+        required: false
+        default: 'false'
+    retry-schedule:
+        description: 'Space-separated delays in seconds between re-checks (used when retry is enabled)'
+        required: false
+        default: '30 60 120 300 300 300 300 300'
+
+runs:
+    using: "composite"
+    steps:
+        -   name: Check package version availability
+            shell: bash
+            run: "${GITHUB_ACTION_PATH}/check-composer-package.bash"
+            env:
+                PACKAGE: ${{ inputs.package }}
+                VERSION: ${{ inputs.version }}
+                REPOSITORY_URL: ${{ inputs.repository-url }}
+                AUTH_KEY: ${{ inputs.auth-key }}
+                AUTH_TOKEN: ${{ inputs.auth-token }}
+                RETRY: ${{ inputs.retry }}
+                RETRY_SCHEDULE: ${{ inputs.retry-schedule }}
+                GITHUB_ACTION_PATH: ${{ github.action_path }}

--- a/actions/check-composer-package/action.yml
+++ b/actions/check-composer-package/action.yml
@@ -16,7 +16,7 @@ inputs:
     repository-url:
         description: 'Composer repository URL'
         required: false
-        default: 'https://repo.packagist.org'
+        default: 'https://repo.packagist.org' # or 'https://updates.ibexa.co' for private packages
     auth-key:
         description: 'HTTP basic auth user (e.g. Satis network key)'
         required: false

--- a/actions/check-composer-package/check-composer-package.bash
+++ b/actions/check-composer-package/check-composer-package.bash
@@ -26,5 +26,5 @@ if check; then
     exit 0
 fi
 
-echo "::error::${PACKAGE}:${VERSION} is not available in ${REPOSITORY_URL%/}"
+echo "::error::${PACKAGE}:${VERSION} is not available in ${REPOSITORY_URL%/}" >&2
 exit 1

--- a/actions/check-composer-package/check-composer-package.bash
+++ b/actions/check-composer-package/check-composer-package.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+check() {
+    local -a curl_auth=()
+    if [[ -n "${AUTH_KEY:-}" ]]; then
+        curl_auth=(-u "${AUTH_KEY}:${AUTH_TOKEN}")
+    fi
+    curl -sf "${curl_auth[@]}" "${REPOSITORY_URL%/}/p2/${PACKAGE}.json" \
+        | jq -e --arg pkg "${PACKAGE}" --arg version "${VERSION}" \
+            '.packages[$pkg][] | select(.version == $version)' > /dev/null
+}
+
+if [[ "${RETRY:-false}" != 'true' ]]; then
+    RETRY_SCHEDULE=''
+fi
+
+for DELAY in ${RETRY_SCHEDULE}; do
+    if check; then
+        exit 0
+    fi
+    echo "${PACKAGE}:${VERSION} not yet available, re-checking in ${DELAY} seconds"
+    sleep "${DELAY}"
+done
+if check; then
+    exit 0
+fi
+
+echo "::error::${PACKAGE}:${VERSION} is not available in ${REPOSITORY_URL%/}"
+exit 1

--- a/actions/create-metapackage-tag/action.yml
+++ b/actions/create-metapackage-tag/action.yml
@@ -110,7 +110,7 @@ runs:
         -   name: Composer update
             shell: bash
             run: |
-                composer update --no-scripts --no-plugins --no-install
+                composer update --no-scripts --no-plugins --no-install # NOSONAR -- regenerating the lock file is the purpose of this action
                 composer validate
 
         -   name: Commit, tag and push

--- a/actions/create-metapackage-tag/action.yml
+++ b/actions/create-metapackage-tag/action.yml
@@ -1,0 +1,124 @@
+name: "Create and push a metapackage release tag"
+author: 'Ibexa AS'
+description: >-
+    Sets metapackage dependency versions for a release — from the
+    releases/<version>/release.json definition in the release repository —
+    updates composer.lock, and, when real-op is enabled, commits, tags and
+    pushes the result using a GitHub App token. The caller must check out
+    the repository first (actions/checkout with persist-credentials: false).
+
+inputs:
+    version:
+        description: 'Version to release, without the v prefix (x.y.z-abcN e.g. 4.5.6-beta1)'
+        required: true
+    pin-packages:
+        description: 'Newline-separated composer package names to pin to the release version'
+        required: true
+    real-op:
+        description: 'Whether to commit, tag and push the changes'
+        required: false
+        default: 'false'
+    git-push-args:
+        description: 'Additional arguments for git push, e.g. --force-with-lease'
+        required: false
+        default: ''
+    gh-client-id:
+        description: 'GitHub App client ID'
+        required: true
+    gh-client-secret:
+        description: 'GitHub App private key'
+        required: true
+    satis-network-key:
+        description: 'Satis Network Key'
+        required: true
+    satis-network-token:
+        description: 'Satis Network Token'
+        required: true
+    php-version:
+        description: 'PHP version used to run composer'
+        required: false
+        default: '8.3'
+    release-repository:
+        description: 'Repository holding the releases/<version>/release.json definitions'
+        required: false
+        default: 'ibexa/release-maker'
+
+runs:
+    using: "composite"
+    steps:
+        -   name: Setup PHP Action
+            uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+            with:
+                php-version: ${{ inputs.php-version }}
+                coverage: none
+                extensions: pdo_sqlite, gd
+
+        -   name: Generate token
+            id: generate_token
+            uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+            with:
+                client-id: ${{ inputs.gh-client-id }}
+                private-key: ${{ inputs.gh-client-secret }}
+                owner: ${{ github.repository_owner }}
+
+        -   name: Get and process release information
+            shell: bash
+            run: "${GITHUB_ACTION_PATH}/fetch-release-map.bash"
+            env:
+                VERSION: ${{ inputs.version }}
+                RELEASE_REPOSITORY: ${{ inputs.release-repository }}
+                RELEASE_MAP: ${{ runner.temp }}/release-map.json
+                GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+                GITHUB_ACTION_PATH: ${{ github.action_path }}
+
+        -   name: Set minimum stability
+            shell: bash
+            run: "${GITHUB_ACTION_PATH}/set-stability.bash"
+            env:
+                VERSION: ${{ inputs.version }}
+                GITHUB_ACTION_PATH: ${{ github.action_path }}
+
+        -   name: Pin packages to the release version
+            shell: bash
+            run: "${GITHUB_ACTION_PATH}/pin-packages.bash"
+            env:
+                VERSION: ${{ inputs.version }}
+                PIN_PACKAGES: ${{ inputs.pin-packages }}
+                GITHUB_ACTION_PATH: ${{ github.action_path }}
+
+        -   name: Patch composer require versions
+            shell: bash
+            run: "${GITHUB_ACTION_PATH}/patch-requires.bash"
+            env:
+                RELEASE_MAP: ${{ runner.temp }}/release-map.json
+                GITHUB_ACTION_PATH: ${{ github.action_path }}
+
+        -   name: Preview composer.json
+            shell: bash
+            run: cat composer.json
+
+        -   name: Add composer keys for private packagist
+            shell: bash
+            run: |
+                composer config http-basic.updates.ibexa.co "$SATIS_NETWORK_KEY" "$SATIS_NETWORK_TOKEN"
+                composer config github-oauth.github.com "$APP_GITHUB_TOKEN"
+            env:
+                SATIS_NETWORK_KEY: ${{ inputs.satis-network-key }}
+                SATIS_NETWORK_TOKEN: ${{ inputs.satis-network-token }}
+                APP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+        -   name: Composer update
+            shell: bash
+            run: |
+                composer update --no-scripts --no-plugins --no-install
+                composer validate
+
+        -   name: Commit, tag and push
+            if: ${{ inputs.real-op == 'true' }}
+            shell: bash
+            run: "${GITHUB_ACTION_PATH}/commit-tag-push.bash"
+            env:
+                VERSION: ${{ inputs.version }}
+                GIT_PUSH_ARGS: ${{ inputs.git-push-args }}
+                GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+                GITHUB_ACTION_PATH: ${{ github.action_path }}

--- a/actions/create-metapackage-tag/action.yml
+++ b/actions/create-metapackage-tag/action.yml
@@ -110,7 +110,7 @@ runs:
         -   name: Composer update
             shell: bash
             run: |
-                composer update --no-scripts --no-plugins --no-install # NOSONAR -- regenerating the lock file is the purpose of this action
+                composer update --no-scripts --no-plugins --no-install
                 composer validate
 
         -   name: Commit, tag and push

--- a/actions/create-metapackage-tag/commit-tag-push.bash
+++ b/actions/create-metapackage-tag/commit-tag-push.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Commits the composer.json/composer.lock changes, tags v<VERSION> and pushes
+# the tag. git is authenticated through gh with GITHUB_TOKEN, scoped to this
+# process — no credentials are written into the remote URL.
+#
+# Required environment: VERSION, GITHUB_TOKEN
+# Optional environment: GIT_PUSH_ARGS
+
+gh auth setup-git
+git config --local user.name "github-actions[bot]"
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add composer.*
+git commit -m "[composer] Set dependencies for ${VERSION} release + .lock"
+git tag "v${VERSION}"
+# shellcheck disable=SC2086 # GIT_PUSH_ARGS is deliberately word-split
+git push origin "v${VERSION}" ${GIT_PUSH_ARGS:-}

--- a/actions/create-metapackage-tag/fetch-release-map.bash
+++ b/actions/create-metapackage-tag/fetch-release-map.bash
@@ -7,6 +7,10 @@ set -euo pipefail
 #
 # Required environment: VERSION, RELEASE_REPOSITORY, RELEASE_MAP, GITHUB_TOKEN
 
-gh api "/repos/${RELEASE_REPOSITORY}/contents/releases/${VERSION}/release.json" --jq '.content' \
-    | base64 --decode \
+if ! CONTENT=$(gh api "/repos/${RELEASE_REPOSITORY}/contents/releases/${VERSION}/release.json" --jq '.content'); then
+    echo "::error::Release definition releases/${VERSION}/release.json is not available in ${RELEASE_REPOSITORY}" >&2
+    exit 1
+fi
+
+base64 --decode <<< "${CONTENT}" \
     | jq '[ .[] | { (.packageName): (.targetVersion) } ] | add' > "${RELEASE_MAP}"

--- a/actions/create-metapackage-tag/fetch-release-map.bash
+++ b/actions/create-metapackage-tag/fetch-release-map.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetches the releases/<VERSION>/release.json definition from RELEASE_REPOSITORY
+# (an array of {packageName, targetVersion} objects) and writes it to RELEASE_MAP
+# as a single {packageName: targetVersion} object.
+#
+# Required environment: VERSION, RELEASE_REPOSITORY, RELEASE_MAP, GITHUB_TOKEN
+
+gh api "/repos/${RELEASE_REPOSITORY}/contents/releases/${VERSION}/release.json" --jq '.content' \
+    | base64 --decode \
+    | jq '[ .[] | { (.packageName): (.targetVersion) } ] | add' > "${RELEASE_MAP}"

--- a/actions/create-metapackage-tag/patch-requires.bash
+++ b/actions/create-metapackage-tag/patch-requires.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Replaces the value of every require entry of composer.json that has a key in
+# the RELEASE_MAP JSON object ({packageName: targetVersion}) with the mapped
+# version, then reformats composer.json to 4-space indentation.
+#
+# Required environment: RELEASE_MAP
+
+jq --slurpfile release "${RELEASE_MAP}" '
+    .require |= (
+        to_entries |
+        map({
+            key: .key,
+            value: (if ($release[0][.key]) then $release[0][.key] else .value end)
+        }) | from_entries
+    )
+' composer.json > composer.json.tmp
+mv composer.json.tmp composer.json
+
+unexpand -t2 composer.json | expand -t4 > composer.json.tmp
+mv composer.json.tmp composer.json

--- a/actions/create-metapackage-tag/pin-packages.bash
+++ b/actions/create-metapackage-tag/pin-packages.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pins each package listed in PIN_PACKAGES (newline-separated composer package
+# names) to VERSION in the require section of composer.json.
+#
+# Required environment: VERSION, PIN_PACKAGES
+
+while IFS= read -r PACKAGE; do
+    if [[ -z "${PACKAGE}" ]]; then
+        continue
+    fi
+    jq --arg pkg "${PACKAGE}" --arg version "${VERSION}" \
+        '.require[$pkg] = $version' composer.json > composer.json.tmp
+    mv composer.json.tmp composer.json
+done <<< "${PIN_PACKAGES}"

--- a/actions/create-metapackage-tag/set-stability.bash
+++ b/actions/create-metapackage-tag/set-stability.bash
@@ -6,13 +6,13 @@ set -euo pipefail
 #
 # Required environment: VERSION
 
-SUFFIX=$(echo "${VERSION}" | cut -d '-' -f 2)
-SET_STABILITY="composer config minimum-stability"
-$SET_STABILITY --unset
+SUFFIX="${VERSION#*-}"
+composer config minimum-stability --unset
 composer config prefer-stable --unset
-case $SUFFIX in
+case ${SUFFIX} in
     alpha*|beta*|rc*) composer config prefer-stable true ;;&
-    alpha*) $SET_STABILITY alpha ;;
-    beta*) $SET_STABILITY beta ;;
-    rc*) $SET_STABILITY rc ;;
+    alpha*) composer config minimum-stability alpha ;;
+    beta*) composer config minimum-stability beta ;;
+    rc*) composer config minimum-stability rc ;;
+    *) ;; # stable version or unrecognized suffix: leave stability unset
 esac

--- a/actions/create-metapackage-tag/set-stability.bash
+++ b/actions/create-metapackage-tag/set-stability.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Derives composer minimum-stability and prefer-stable from the pre-release
+# suffix of VERSION (e.g. 4.5.6-beta1 -> beta); stable versions get both unset.
+#
+# Required environment: VERSION
+
+SUFFIX=$(echo "${VERSION}" | cut -d '-' -f 2)
+SET_STABILITY="composer config minimum-stability"
+$SET_STABILITY --unset
+composer config prefer-stable --unset
+case $SUFFIX in
+    alpha*|beta*|rc*) composer config prefer-stable true ;;&
+    alpha*) $SET_STABILITY alpha ;;
+    beta*) $SET_STABILITY beta ;;
+    rc*) $SET_STABILITY rc ;;
+esac

--- a/tests/check-composer-package.bats
+++ b/tests/check-composer-package.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$BATS_TEST_DIRNAME/../actions/check-composer-package/check-composer-package.bash"
+
+setup() {
+    setup_stub_path
+
+    export CURL_LOG="$BATS_TEST_TMPDIR/curl.log"
+    export CURL_COUNT_FILE="$BATS_TEST_TMPDIR/curl.count"
+    export CURL_RESPONSES_DIR="$BATS_TEST_TMPDIR/responses"
+    export SLEEP_LOG="$BATS_TEST_TMPDIR/sleep.log"
+    mkdir -p "$CURL_RESPONSES_DIR"
+    touch "$CURL_LOG" "$SLEEP_LOG"
+
+    # Responds with $CURL_RESPONSES_DIR/response.<call number> when present,
+    # otherwise fails like curl -f does on an HTTP error.
+    stub_command curl '
+echo "curl $*" >> "$CURL_LOG"
+COUNT=$(( $(cat "$CURL_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+echo "$COUNT" > "$CURL_COUNT_FILE"
+if [[ -f "$CURL_RESPONSES_DIR/response.$COUNT" ]]; then
+    cat "$CURL_RESPONSES_DIR/response.$COUNT"
+else
+    exit 22
+fi'
+
+    stub_command sleep 'echo "$1" >> "$SLEEP_LOG"'
+
+    export PACKAGE='ibexa/experience'
+    export VERSION='v4.6.30'
+    export REPOSITORY_URL='https://updates.ibexa.co'
+    export RETRY='false'
+    export RETRY_SCHEDULE='5 7'
+    unset AUTH_KEY AUTH_TOKEN
+}
+
+metadata_with_version() {
+    printf '{"packages": {"%s": [{"version": "v4.6.29"}, {"version": "%s"}]}}' "$PACKAGE" "$1"
+}
+
+curl_calls() {
+    grep -c '^curl ' "$CURL_LOG"
+}
+
+@test "succeeds when the version is available" {
+    metadata_with_version "$VERSION" > "$CURL_RESPONSES_DIR/response.1"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(curl_calls)" -eq 1 ]
+    [ ! -s "$SLEEP_LOG" ]
+}
+
+@test "fails fast without retry when the version is missing" {
+    metadata_with_version 'v4.6.29' > "$CURL_RESPONSES_DIR/response.1"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 1 ]
+    [ "$(curl_calls)" -eq 1 ]
+    [ ! -s "$SLEEP_LOG" ]
+    [[ "$output" == *"::error::ibexa/experience:v4.6.30 is not available in https://updates.ibexa.co"* ]]
+}
+
+@test "fails fast without retry even when a retry schedule is set" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 1 ]
+    [ "$(curl_calls)" -eq 1 ]
+    [ ! -s "$SLEEP_LOG" ]
+}
+
+@test "with retry, re-checks on the schedule and fails after the final check" {
+    export RETRY='true'
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 1 ]
+    [ "$(curl_calls)" -eq 3 ]
+    [ "$(cat "$SLEEP_LOG")" = $'5\n7' ]
+    [[ "$output" == *'not yet available, re-checking in 5 seconds'* ]]
+    [[ "$output" == *'not yet available, re-checking in 7 seconds'* ]]
+    [[ "$output" == *'::error::'* ]]
+}
+
+@test "with retry, succeeds as soon as the version appears" {
+    export RETRY='true'
+    metadata_with_version 'v4.6.29' > "$CURL_RESPONSES_DIR/response.1"
+    metadata_with_version "$VERSION" > "$CURL_RESPONSES_DIR/response.2"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(curl_calls)" -eq 2 ]
+    [ "$(cat "$SLEEP_LOG")" = '5' ]
+}
+
+@test "passes HTTP basic auth to curl when configured" {
+    export AUTH_KEY='satis-key'
+    export AUTH_TOKEN='satis-token'
+    metadata_with_version "$VERSION" > "$CURL_RESPONSES_DIR/response.1"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q -- '-u satis-key:satis-token' "$CURL_LOG"
+}
+
+@test "requests anonymously when no auth is configured" {
+    metadata_with_version "$VERSION" > "$CURL_RESPONSES_DIR/response.1"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    ! grep -q -- '-u ' "$CURL_LOG"
+}
+
+@test "queries the composer v2 metadata endpoint, trimming a trailing repository URL slash" {
+    export REPOSITORY_URL='https://updates.ibexa.co/'
+    metadata_with_version "$VERSION" > "$CURL_RESPONSES_DIR/response.1"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q 'https://updates.ibexa.co/p2/ibexa/experience.json' "$CURL_LOG"
+}
+
+@test "treats an HTTP-level curl failure as the version being unavailable" {
+    export RETRY='true'
+    export RETRY_SCHEDULE='5'
+    # No response files at all: every curl call exits 22.
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 1 ]
+    [ "$(curl_calls)" -eq 2 ]
+    [[ "$output" == *'::error::'* ]]
+}

--- a/tests/commit-tag-push.bats
+++ b/tests/commit-tag-push.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$BATS_TEST_DIRNAME/../actions/create-metapackage-tag/commit-tag-push.bash"
+
+setup() {
+    setup_stub_path
+
+    cd "$BATS_TEST_TMPDIR"
+    touch composer.json composer.lock
+
+    export CMD_LOG="$BATS_TEST_TMPDIR/cmd.log"
+    touch "$CMD_LOG"
+    stub_command git 'echo "git $*" >> "$CMD_LOG"'
+    stub_command gh 'echo "gh $*" >> "$CMD_LOG"'
+
+    export VERSION='4.6.30'
+    export GIT_PUSH_ARGS=''
+}
+
+@test "authenticates, commits, tags and pushes in order" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$CMD_LOG")" = 'gh auth setup-git
+git config --local user.name github-actions[bot]
+git config --local user.email 41898282+github-actions[bot]@users.noreply.github.com
+git add composer.json composer.lock
+git commit -m [composer] Set dependencies for 4.6.30 release + .lock
+git tag v4.6.30
+git push origin v4.6.30' ]
+}
+
+@test "appends extra git push arguments when provided" {
+    GIT_PUSH_ARGS='--force-with-lease' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q '^git push origin v4.6.30 --force-with-lease$' "$CMD_LOG"
+}
+
+@test "fails when the commit fails" {
+    stub_command git '
+echo "git $*" >> "$CMD_LOG"
+if [[ "$1" == "commit" ]]; then
+    exit 1
+fi'
+
+    run "$SCRIPT"
+
+    [ "$status" -ne 0 ]
+    ! grep -q '^git tag' "$CMD_LOG"
+}

--- a/tests/fetch-release-map.bats
+++ b/tests/fetch-release-map.bats
@@ -41,10 +41,15 @@ cat "$GH_RESPONSE"'
     grep -q 'gh api /repos/ibexa/release-maker/contents/releases/4.6.30/release.json --jq .content' "$GH_LOG"
 }
 
-@test "fails when gh fails" {
-    stub_command gh 'exit 1'
+@test "fails with an attributable error when the release definition is missing" {
+    stub_command gh '
+echo "gh: Not Found (HTTP 404)" >&2
+exit 1'
 
     run "$SCRIPT"
 
     [ "$status" -ne 0 ]
+    [[ "$output" == *'::error::Release definition releases/4.6.30/release.json is not available in ibexa/release-maker'* ]]
+    [[ "$output" != *'base64'* ]]
+    [ ! -e "$RELEASE_MAP" ]
 }

--- a/tests/fetch-release-map.bats
+++ b/tests/fetch-release-map.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$BATS_TEST_DIRNAME/../actions/create-metapackage-tag/fetch-release-map.bash"
+
+setup() {
+    setup_stub_path
+
+    export GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+    export GH_RESPONSE="$BATS_TEST_TMPDIR/gh.response"
+    touch "$GH_LOG"
+
+    stub_command gh '
+echo "gh $*" >> "$GH_LOG"
+cat "$GH_RESPONSE"'
+
+    export VERSION='4.6.30'
+    export RELEASE_REPOSITORY='ibexa/release-maker'
+    export RELEASE_MAP="$BATS_TEST_TMPDIR/release-map.json"
+}
+
+@test "turns the release.json array into a packageName->targetVersion map" {
+    printf '[
+        {"packageName": "ibexa/core", "targetVersion": "v4.6.30", "irrelevant": "x"},
+        {"packageName": "ibexa/admin-ui", "targetVersion": "v4.6.31"}
+    ]' | base64 > "$GH_RESPONSE"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -c -S . "$RELEASE_MAP")" = '{"ibexa/admin-ui":"v4.6.31","ibexa/core":"v4.6.30"}' ]
+}
+
+@test "requests the release definition for the given version from the release repository" {
+    printf '[]' | base64 > "$GH_RESPONSE"
+
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q 'gh api /repos/ibexa/release-maker/contents/releases/4.6.30/release.json --jq .content' "$GH_LOG"
+}
+
+@test "fails when gh fails" {
+    stub_command gh 'exit 1'
+
+    run "$SCRIPT"
+
+    [ "$status" -ne 0 ]
+}

--- a/tests/patch-requires.bats
+++ b/tests/patch-requires.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$BATS_TEST_DIRNAME/../actions/create-metapackage-tag/patch-requires.bash"
+
+setup() {
+    cd "$BATS_TEST_TMPDIR"
+    printf '{
+        "name": "ibexa/commerce",
+        "require": {
+            "ibexa/core": "~4.6.0",
+            "ibexa/admin-ui": "~4.6.0",
+            "other/package": "^1.0"
+        },
+        "extra": {
+            "unrelated": true
+        }
+    }' > composer.json
+
+    export RELEASE_MAP="$BATS_TEST_TMPDIR/release-map.json"
+    printf '{
+        "ibexa/core": "v4.6.30",
+        "ibexa/admin-ui": "v4.6.31",
+        "not/required-here": "v9.9.9"
+    }' > "$RELEASE_MAP"
+}
+
+@test "replaces require versions for packages present in the release map" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.require["ibexa/core"]' composer.json)" = 'v4.6.30' ]
+    [ "$(jq -r '.require["ibexa/admin-ui"]' composer.json)" = 'v4.6.31' ]
+}
+
+@test "keeps require entries that are not in the release map" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.require["other/package"]' composer.json)" = '^1.0' ]
+}
+
+@test "does not add release map packages that are not required" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq '.require | has("not/required-here")' composer.json)" = 'false' ]
+}
+
+@test "leaves other sections untouched" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq '.extra.unrelated' composer.json)" = 'true' ]
+    [ "$(jq -r '.name' composer.json)" = 'ibexa/commerce' ]
+}
+
+@test "reformats composer.json to 4-space indentation" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q '^    "require"' composer.json
+    grep -q '^        "ibexa/core"' composer.json
+}
+
+@test "leaves no temporary file behind" {
+    run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ ! -e composer.json.tmp ]
+}

--- a/tests/pin-packages.bats
+++ b/tests/pin-packages.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$BATS_TEST_DIRNAME/../actions/create-metapackage-tag/pin-packages.bash"
+
+setup() {
+    cd "$BATS_TEST_TMPDIR"
+    printf '{
+        "name": "ibexa/commerce",
+        "require": {
+            "ibexa/experience": "~4.6.0",
+            "other/package": "^1.0"
+        }
+    }' > composer.json
+
+    export VERSION='4.6.30'
+}
+
+@test "pins a single package to the release version" {
+    PIN_PACKAGES='ibexa/experience' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.require["ibexa/experience"]' composer.json)" = '4.6.30' ]
+    [ "$(jq -r '.require["other/package"]' composer.json)" = '^1.0' ]
+    [ "$(jq -r '.name' composer.json)" = 'ibexa/commerce' ]
+}
+
+@test "pins every package of a multi-line list" {
+    PIN_PACKAGES=$'ibexa/experience\nother/package' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.require["ibexa/experience"]' composer.json)" = '4.6.30' ]
+    [ "$(jq -r '.require["other/package"]' composer.json)" = '4.6.30' ]
+}
+
+@test "ignores blank lines in the list" {
+    PIN_PACKAGES=$'\nibexa/experience\n\n' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.require["ibexa/experience"]' composer.json)" = '4.6.30' ]
+    [ "$(jq '.require | length' composer.json)" -eq 2 ]
+}
+
+@test "leaves no temporary file behind" {
+    PIN_PACKAGES='ibexa/experience' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ ! -e composer.json.tmp ]
+}

--- a/tests/set-stability.bats
+++ b/tests/set-stability.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$BATS_TEST_DIRNAME/../actions/create-metapackage-tag/set-stability.bash"
+
+setup() {
+    setup_stub_path
+
+    export COMPOSER_LOG="$BATS_TEST_TMPDIR/composer.log"
+    touch "$COMPOSER_LOG"
+    stub_command composer 'echo "composer $*" >> "$COMPOSER_LOG"'
+}
+
+@test "unsets minimum-stability and prefer-stable for a stable version" {
+    VERSION='4.6.30' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "$COMPOSER_LOG")" = 'composer config minimum-stability --unset
+composer config prefer-stable --unset' ]
+}
+
+@test "sets alpha stability for an alpha version" {
+    VERSION='4.6.30-alpha2' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q '^composer config prefer-stable true$' "$COMPOSER_LOG"
+    grep -q '^composer config minimum-stability alpha$' "$COMPOSER_LOG"
+}
+
+@test "sets beta stability for a beta version" {
+    VERSION='4.6.30-beta1' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q '^composer config prefer-stable true$' "$COMPOSER_LOG"
+    grep -q '^composer config minimum-stability beta$' "$COMPOSER_LOG"
+}
+
+@test "sets rc stability for a release candidate version" {
+    VERSION='4.6.30-rc1' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    grep -q '^composer config prefer-stable true$' "$COMPOSER_LOG"
+    grep -q '^composer config minimum-stability rc$' "$COMPOSER_LOG"
+}
+
+@test "leaves stability unset for an unrecognized suffix" {
+    VERSION='4.6.30-dev1' run "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    ! grep -q 'prefer-stable true' "$COMPOSER_LOG"
+    ! grep -qE 'minimum-stability (alpha|beta|rc)' "$COMPOSER_LOG"
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -5,6 +5,7 @@ setup_stub_path() {
     STUB_BIN="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$STUB_BIN"
     PATH="$STUB_BIN:$PATH"
+    return 0
 }
 
 # stub_command <name> <script body...> — creates an executable stub on the stub PATH.
@@ -13,4 +14,5 @@ stub_command() {
     shift
     printf '#!/usr/bin/env bash\n%s\n' "$*" > "$STUB_BIN/$name"
     chmod +x "$STUB_BIN/$name"
+    return 0
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,16 @@
+# Common helpers for the bats suites.
+
+# Puts a stub bin directory first on PATH; call from setup().
+setup_stub_path() {
+    STUB_BIN="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$STUB_BIN"
+    PATH="$STUB_BIN:$PATH"
+}
+
+# stub_command <name> <script body...> — creates an executable stub on the stub PATH.
+stub_command() {
+    local name=$1
+    shift
+    printf '#!/usr/bin/env bash\n%s\n' "$*" > "$STUB_BIN/$name"
+    chmod +x "$STUB_BIN/$name"
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11778 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/oss/pull/285
- https://github.com/ibexa/headless/pull/286
- https://github.com/ibexa/experience/pull/604
- https://github.com/ibexa/commerce/pull/1891

#### TL;DR; 

This refactoring extracts redundant steps from meta-packages, tackling a few issues at once:
- update of usage of Node.js 20 deprecated actions,
- easier future update of outdated GHA workflows as they now reside mostly in this repository,
- refactoring of the legacy approaches in the release process.

🧑 Generated with carbon-based interface

#### Description:

The `auto_tag.yml` (Create Tag) workflows in the metapackage repositories (oss, headless, experience, commerce) are ~90% identical copies. The trigger for touching them: several of their actions still ran on the deprecated Node.js 20 runtime, which GitHub removes from its runners on 16 September 2026. This PR adds two composite actions extracting the common logic, so each workflow keeps only its edition-specific data (see the related PRs, which shrink each workflow to 40–60 lines):

**`actions/check-composer-package`** — checks that a package version is available in a Composer repository: Packagist by default, or a Satis instance via `repository-url` + basic auth. With `retry: true` it re-checks on a configurable `retry-schedule` (the default reproduces the commerce Satis wait: 30/60/120 s ramp-up, then 5 × 300 s, ~28.5 min worst case). It replaces both preparation-phase patterns used so far:
- the GitHub-tag existence probe (oss/headless) — a flawed proxy, since a tag can exist while the package is not yet installable (e.g. `ibexa/headless-assets` is served by Satis, which is rebuilt by a 5-minute cron), and
- the inline Satis wait loop (commerce).

**`actions/create-metapackage-tag`** — the whole tagging job: fetches `releases/<version>/release.json` from the release repository (input, default `ibexa/release-maker`), derives minimum stability from the version suffix, pins the parent/assets packages (`pin-packages` input), patches the require versions from the release definition, updates `composer.lock`, and — behind `real-op` — commits, tags and pushes using a GitHub App token via `gh auth setup-git`.

Implementation notes:
- Shell logic lives in `.bash` scripts next to each `action.yml` (the `composer-install` convention) and receives inputs via the environment — no `${{ }}` interpolation inside scripts.
- The `sponge`/moreutils dependency of the original steps is dropped (tmpfile + `mv`), removing an `apt-get install` from every run.
- Third-party actions are SHA-pinned with version comments.
- The push step authenticates with the automation GitHub App token via `gh auth setup-git`, replacing the legacy `EZROBOT_PAT` — no secret lands in the remote URL or `.git/config`, and release commits are authored as `github-actions[bot]`.
- The caller workflows run on `ubuntu-26.04` runners and `actions/checkout` v7.
- A new CI workflow runs the bats test suites (30 tests, stubbing curl/sleep/gh/git/composer via PATH) and actionlint (version- and checksum-pinned) on pull requests and pushes to main.

#### For QA:

No manual QA required. The actions are exercised by a harness on ibexa/gha-testing (`auto_tag_mock.yaml`, added in ibexa/gha-testing#3), which mirrors the metapackage Create Tag workflow and covers all three preparation variants plus the tag path in a single dispatch.

Test status:

- [x] :green_circle: `check-composer-package` in all three variants used across the editions — Packagist anonymous (as in ibexa/oss), Satis authenticated (ibexa/headless) and Satis with `retry` (ibexa/commerce) [Create Tag (mock) run 30383513903](https://github.com/ibexa/gha-testing/actions/runs/30383513903)
- [x] :green_circle: `create-metapackage-tag` end to end, including the `real_op` path that commits, tags and pushes, with `git-push-args` passed through as `--force` — same [run 30383513903](https://github.com/ibexa/gha-testing/actions/runs/30383513903), moving [ibexa/gha-testing@v5.0.9](https://github.com/ibexa/gha-testing/releases/tag/v5.0.9) to `ca4aa52`, authored as `github-actions[bot]`
- [x] :green_circle: The tag pushed with the GitHub App token triggers the release chain, which consumes the `composer.lock` the action generated [Create Release for tag run 30382176038](https://github.com/ibexa/gha-testing/actions/runs/30382176038) producing [ibexa/gha-testing@v5.0.9](https://github.com/ibexa/gha-testing/releases/tag/v5.0.9) and [Changelog-v5.0.9](https://github.com/ibexa/gha-testing/wiki/Changelog-v5.0.9), correctly diffing `ibexa/admin-ui-assets`, `ibexa/headless-assets` and `ibexa/core` between 5.0.8 and 5.0.9

- [x] :green_circle: Both actions consumed from a branch ref by all four metapackage Create Tag workflows, dry runs at 4.6.31 (`real_op: false`) — each edition's preparation variant and pin list verified, push step skipped, `ubuntu-26.04`: [oss run 31009047336](https://github.com/ibexa/oss/actions/runs/31009047336), [headless run 31009050345](https://github.com/ibexa/headless/actions/runs/31009050345), [experience run 31009052741](https://github.com/ibexa/experience/actions/runs/31009052741), [commerce run 31009055791](https://github.com/ibexa/commerce/actions/runs/31009055791) — details in each pull request's For QA section

- [x] :green_circle: Negative paths, dispatches with bogus version 9.9.9-test1: retry exhaustion on the harness with a shortened `retry-schedule: "5 5"` — three checks, two waits, explicit `::error::` in ~13 s [Create Tag (mock) run 31010159248](https://github.com/ibexa/gha-testing/actions/runs/31010159248); fail-fast preparation with the `action` job skipped on [oss run 31010161799](https://github.com/ibexa/oss/actions/runs/31010161799) and [headless run 31010164723](https://github.com/ibexa/headless/actions/runs/31010164723); release-definition 404 failing the action on [experience run 31012128038](https://github.com/ibexa/experience/actions/runs/31012128038) with `::error::Release definition releases/9.9.9-test1/release.json is not available in ibexa/release-maker` (re-run after the error was made attributable). No tag or push anywhere
**For the caller PRs:** the push path (`real_op: true`) is verified on the harness above, and the automation App is installed org-wide — each dry run minted a token "for all repositories owned by ibexa" — with `contents: write` proven by the harness pushes. No per-repo verification remains.

#### Documentation:

No documentation required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


