### PR TITLE
IBX-12062: Add nightly backend CI fanout workflow

### DIFF
--- a/.github/workflows/nightly-backend-ci.yml
+++ b/.github/workflows/nightly-backend-ci.yml
@@ -1,0 +1,42 @@
+name: Nightly backend CI
+
+on:
+    schedule:
+        # Run every night at 02:00 UTC
+        - cron: "0 2 * * *"
+    workflow_dispatch: ~
+
+jobs:
+    nightly:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            # Keep the number of concurrently dispatched pipelines reasonable
+            max-parallel: 3
+            matrix:
+                repository:
+                    - ibexa/admin-ui
+                    - ibexa/core
+                    - ibexa/checkout
+                branch:
+                    - "4.6"
+                    - "5.0"
+                    - "6.0"
+        steps:
+            - uses: actions/create-github-app-token@v3
+              id: generate_token
+              with:
+                  app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                  private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+                  owner: ${{ github.repository_owner }}
+
+            - name: Trigger backend CI on ${{ matrix.repository }}@${{ matrix.branch }}
+              shell: bash
+              run: |
+                  gh api --method POST \
+                    "/repos/${{ matrix.repository }}/actions/workflows/backend-ci.yaml/dispatches" \
+                    -f ref="${{ matrix.branch }}"
+                    # Re-enable once Phase 0 adds the input to each backend-ci.yaml:
+                    # -f "inputs[send-success-notification]=false"
+              env:
+                  GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/nightly-backend-ci.yml
+++ b/.github/workflows/nightly-backend-ci.yml
@@ -23,10 +23,10 @@ jobs:
                     - "5.0"
                     - "6.0"
         steps:
-            - uses: actions/create-github-app-token@v3
+            - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               id: generate_token
               with:
-                  app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                  client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                   private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
                   owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## What

Adds `.github/workflows/nightly-backend-ci.yml` — a nightly fanout that dispatches each target repo's `backend-ci.yaml`.

- **Schedule:** nightly at 02:00 UTC + manual `workflow_dispatch`
- **Matrix:** `ibexa/admin-ui`, `ibexa/core`, `ibexa/checkout` × branches `4.6`, `5.0`, `6.0` (9 dispatches)
- Uses `actions/create-github-app-token` (`AUTOMATION_CLIENT_ID` / `AUTOMATION_CLIENT_SECRET`) then `gh api … /dispatches`
- Mirrors the existing `ibexa/oss` `nightly.yml` pattern, retargeted at `backend-ci.yaml`
